### PR TITLE
codex-honcho: harness-level Honcho memory for OpenAI Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,107 @@ Persistent memory for [OpenAI Codex](https://developers.openai.com/codex) sessio
 
 A harness-level integration: Codex lifecycle hooks feed every turn into Honcho and surface relevant context back at prompt time, so the model remembers across sessions. Sibling to [`claude-honcho`](https://github.com/plastic-labs/claude-honcho) — same memory backend, different harness.
 
-## Status
+## What it does
 
-Early. Building the harness adapter layer; the Honcho-side logic is shared with the Claude plugin.
+```
+┌─ Codex session ──────────────────────────────────────────────┐
+│                                                               │
+│  SessionStart ──▶ recall    ──▶ inject context + dialectic    │
+│  UserPromptSubmit ─▶ prompt  ──▶ inject prompt-relevant memory │
+│  PostToolUse  ──▶ observe   ──▶ record tool activity          │
+│  Stop / PreCompact ─▶ writeback ─▶ ship new turns to Honcho    │
+│                                                               │
+└───────────────────────────┬───────────────────────────────────┘
+                            │  reads/writes
+                  ┌─────────▼──────────┐      ┌────────────────────┐
+                  │  Honcho API (SDK)  │      │  Honcho hosted MCP  │
+                  │  context · messages│      │  mcp.honcho.dev     │
+                  └────────────────────┘      │  search · chat · …  │
+                                              └────────────────────┘
+```
 
-## How it works
+- **Read path** — `recall` (SessionStart) and `prompt` (UserPromptSubmit) print a `<honcho-memory>` block to stdout, which Codex injects as context. `recall` also fires bounded dialectic reasoning to keep Honcho's model of you sharp, and re-runs after compaction.
+- **Write path** — `writeback` runs on every `Stop` (Codex is turn-scoped; there's no SessionEnd) and on `PreCompact`. It reads the session rollout and ships only the turns added since the last cursor — no daemon, no duplicates.
+- **Active recall** — the hosted Honcho MCP (`mcp.honcho.dev`) is registered in Codex so the model can `search` / `chat` / `get_context` on demand. A bundled `honcho-memory` skill tells it when to.
 
-Codex exposes a hook system (`~/.codex/hooks.json`, gated behind `[features].hooks = true` in `~/.codex/config.toml`). codex-honcho wires four events:
+## Requirements
 
-| Event | Role |
+- [Codex CLI](https://developers.openai.com/codex) with hooks support
+- [bun](https://bun.sh)
+- A Honcho API key — via the [Honcho CLI](https://honcho.dev): `uv tool install honcho-cli && honcho init` (writes `~/.honcho/config.json`), or `export HONCHO_API_KEY=hch-…`
+- `npx` on PATH (the MCP registration uses `mcp-remote`)
+
+## Install
+
+```bash
+git clone https://github.com/plastic-labs/codex-honcho
+cd codex-honcho
+./install.sh
+```
+
+Or manually:
+
+```bash
+bun install
+bun run bin/codex-honcho.ts install
+```
+
+Then restart Codex. Check state any time:
+
+```bash
+bun run bin/codex-honcho.ts status
+bun run bin/codex-honcho.ts remove   # clean uninstall
+```
+
+## What install writes
+
+| Path | Change |
 |---|---|
-| `SessionStart` | warm context, materialize the Honcho session |
-| `UserPromptSubmit` | inject relevant memory ahead of the model |
-| `PostToolUse` | record tool activity as observations |
-| `Stop` | per-turn writeback of the conversation to Honcho |
+| `~/.codex/hooks.json` | adds the codex-honcho hook entries (merged, never clobbers yours) |
+| `~/.codex/config.toml` | sets `[features].hooks = true` and registers `[mcp_servers.honcho]` |
+| `~/.codex/skills/honcho-memory/` | installs the active-recall skill |
 
-Codex `Stop` is turn-scoped (there is no final `SessionEnd`), so writeback is incremental: each turn we read the new tail of the session rollout file and ship only the delta.
+`remove` strips exactly these and leaves everything else intact.
+
+## Configuration
+
+codex-honcho reads `~/.honcho/config.json` (shared with the other Honcho integrations). Codex-specific settings live under `hosts.codex`; root fields are the fallback.
+
+```json
+{
+  "apiKey": "hch-…",
+  "peerName": "eri",
+  "hosts": {
+    "codex": {
+      "workspace": "codex",
+      "aiPeer": "codex",
+      "reasoningLevel": "low",
+      "saveMessages": true,
+      "enabled": true
+    }
+  }
+}
+```
+
+Env overrides: `HONCHO_API_KEY`, `HONCHO_PEER_NAME`, `HONCHO_CONFIG_DIR`.
 
 ## Layout
 
 ```
-src/
-  transcript/   Codex rollout (.jsonl) reader
-  connectors/   installs/removes the Codex hook + feature flag
-  hooks/        the four hook handlers
-  mcp/          Honcho memory tools exposed to Codex
+bin/codex-honcho.ts      CLI: install · remove · status · <hook-verb>
+src/transcript/codex.ts  Codex rollout (.jsonl) reader
+src/connectors/          installs hooks · MCP server · skill into ~/.codex
+src/hooks/               recall · prompt · observe · writeback
+src/cursor.ts            per-turn writeback delta tracker
+src/config.ts            resolves the `codex` host from ~/.honcho/config.json
+skills/honcho-memory/    active-recall guidance for the model
+```
+
+## Development
+
+```bash
+bun test          # unit suite
+bun run typecheck
 ```
 
 ## License

--- a/bin/codex-honcho.ts
+++ b/bin/codex-honcho.ts
@@ -7,6 +7,8 @@ import {
   DEFAULT_HOOKS_PATH,
   DEFAULT_CONFIG_PATH,
 } from "../src/connectors/codex.ts";
+import { installMcpServer, removeMcpServer, type McpIdentity } from "../src/connectors/mcp.ts";
+import { loadConfig } from "../src/config.ts";
 
 const command = process.argv[2] ?? "";
 
@@ -21,18 +23,41 @@ async function runHook(verb: string): Promise<void> {
   }
 }
 
+function mcpIdentity(): McpIdentity | null {
+  const config = loadConfig();
+  if (!config) return null;
+  return {
+    apiKey: config.apiKey,
+    userName: config.peerName,
+    workspaceId: config.workspace,
+    assistantName: config.aiPeer,
+  };
+}
+
 switch (command) {
-  case "install":
+  case "install": {
     installCodexHooks();
     console.log(`Installed Codex hooks → ${DEFAULT_HOOKS_PATH}`);
     console.log(`Enabled [features].hooks → ${DEFAULT_CONFIG_PATH}`);
+    const id = mcpIdentity();
+    if (id) {
+      installMcpServer(id);
+      console.log(`Registered Honcho MCP (mcp.honcho.dev) → ${DEFAULT_CONFIG_PATH}`);
+    } else {
+      console.log("Skipped MCP registration — no Honcho API key found. Run `honcho init`, then re-run install.");
+    }
     break;
+  }
   case "remove":
-  case "uninstall":
-    console.log(removeCodexHooks() ? "Removed Codex hooks." : "No codex-honcho hooks found.");
+  case "uninstall": {
+    const hooksGone = removeCodexHooks();
+    const mcpGone = removeMcpServer();
+    console.log(hooksGone || mcpGone ? "Removed codex-honcho hooks and MCP registration." : "No codex-honcho install found.");
     break;
+  }
   case "status":
     console.log(hasCodexHooks() ? "codex-honcho hooks: installed" : "codex-honcho hooks: not installed");
+    console.log(loadConfig() ? "honcho config: found" : "honcho config: missing (run `honcho init`)");
     break;
   default:
     await runHook(command);

--- a/bin/codex-honcho.ts
+++ b/bin/codex-honcho.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 import { fileURLToPath } from "node:url";
 import { dispatch, isVerb } from "../src/dispatch.ts";
-import { runDetached, isBackground } from "../src/background.ts";
 import {
   installCodexHooks,
   removeCodexHooks,
@@ -11,12 +10,11 @@ import {
 } from "../src/connectors/codex.ts";
 import { installMcpServer, removeMcpServer, type McpIdentity } from "../src/connectors/mcp.ts";
 import { installSkill, removeSkill, hasSkill } from "../src/connectors/skill.ts";
-import { loadConfig } from "../src/config.ts";
+import { loadConfig, memoryKey } from "../src/config.ts";
+import { pendingCount } from "../src/queue.ts";
 
 const command = process.argv[2] ?? "";
 
-// Write-only verbs run detached so the turn never blocks on the network.
-const DETACH = new Set(["writeback", "observe"]);
 // Verbs whose output is injected as model-only context (not shown to the user).
 const INJECT_EVENT: Record<string, string> = {
   recall: "SessionStart",
@@ -26,11 +24,6 @@ const INJECT_EVENT: Record<string, string> = {
 async function runHook(verb: string): Promise<void> {
   const stdin = await Bun.stdin.text();
   if (!isVerb(verb)) return;
-
-  if (DETACH.has(verb) && !isBackground()) {
-    runDetached(verb, stdin);
-    return;
-  }
 
   try {
     const out = await dispatch(verb, stdin);
@@ -82,11 +75,17 @@ switch (command) {
     console.log(hooksGone || mcpGone || skillGone ? "Removed codex-honcho hooks, MCP registration, and skill." : "No codex-honcho install found.");
     break;
   }
-  case "status":
+  case "status": {
     console.log(hasCodexHooks() ? "codex-honcho hooks: installed" : "codex-honcho hooks: not installed");
     console.log(hasSkill() ? "memory skill: installed" : "memory skill: not installed");
-    console.log(loadConfig() ? "honcho config: found" : "honcho config: missing (run `honcho init`)");
+    const cfg = loadConfig();
+    console.log(cfg ? "honcho config: found" : "honcho config: missing (run `honcho init`)");
+    if (cfg) {
+      const key = memoryKey(cfg, process.cwd());
+      console.log(`queue (${key}): ${pendingCount(key)} pending upload`);
+    }
     break;
+  }
   default:
     await runHook(command);
 }

--- a/bin/codex-honcho.ts
+++ b/bin/codex-honcho.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_CONFIG_PATH,
 } from "../src/connectors/codex.ts";
 import { installMcpServer, removeMcpServer, type McpIdentity } from "../src/connectors/mcp.ts";
+import { installSkill, removeSkill, hasSkill } from "../src/connectors/skill.ts";
 import { loadConfig } from "../src/config.ts";
 
 const command = process.argv[2] ?? "";
@@ -39,6 +40,7 @@ switch (command) {
     installCodexHooks();
     console.log(`Installed Codex hooks → ${DEFAULT_HOOKS_PATH}`);
     console.log(`Enabled [features].hooks → ${DEFAULT_CONFIG_PATH}`);
+    console.log(`Installed memory skill → ${installSkill()}`);
     const id = mcpIdentity();
     if (id) {
       installMcpServer(id);
@@ -52,11 +54,13 @@ switch (command) {
   case "uninstall": {
     const hooksGone = removeCodexHooks();
     const mcpGone = removeMcpServer();
-    console.log(hooksGone || mcpGone ? "Removed codex-honcho hooks and MCP registration." : "No codex-honcho install found.");
+    const skillGone = removeSkill();
+    console.log(hooksGone || mcpGone || skillGone ? "Removed codex-honcho hooks, MCP registration, and skill." : "No codex-honcho install found.");
     break;
   }
   case "status":
     console.log(hasCodexHooks() ? "codex-honcho hooks: installed" : "codex-honcho hooks: not installed");
+    console.log(hasSkill() ? "memory skill: installed" : "memory skill: not installed");
     console.log(loadConfig() ? "honcho config: found" : "honcho config: missing (run `honcho init`)");
     break;
   default:

--- a/bin/codex-honcho.ts
+++ b/bin/codex-honcho.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { fileURLToPath } from "node:url";
-import { dispatch, isHookVerb } from "../src/dispatch.ts";
+import { dispatch, isVerb } from "../src/dispatch.ts";
+import { runDetached, isBackground } from "../src/background.ts";
 import {
   installCodexHooks,
   removeCodexHooks,
@@ -14,12 +15,31 @@ import { loadConfig } from "../src/config.ts";
 
 const command = process.argv[2] ?? "";
 
+// Write-only verbs run detached so the turn never blocks on the network.
+const DETACH = new Set(["writeback", "observe"]);
+// Verbs whose output is injected as model-only context (not shown to the user).
+const INJECT_EVENT: Record<string, string> = {
+  recall: "SessionStart",
+  prompt: "UserPromptSubmit",
+};
+
 async function runHook(verb: string): Promise<void> {
   const stdin = await Bun.stdin.text();
-  if (!isHookVerb(verb)) return;
+  if (!isVerb(verb)) return;
+
+  if (DETACH.has(verb) && !isBackground()) {
+    runDetached(verb, stdin);
+    return;
+  }
+
   try {
     const out = await dispatch(verb, stdin);
-    if (out) process.stdout.write(out + "\n");
+    if (!out) return;
+    const event = INJECT_EVENT[verb];
+    const payload = event
+      ? JSON.stringify({ hookSpecificOutput: { hookEventName: event, additionalContext: out } })
+      : out;
+    process.stdout.write(payload + "\n");
   } catch {
     // Never surface a hook failure to Codex.
   }

--- a/bin/codex-honcho.ts
+++ b/bin/codex-honcho.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import { fileURLToPath } from "node:url";
 import { dispatch, isHookVerb } from "../src/dispatch.ts";
 import {
   installCodexHooks,
@@ -37,7 +38,10 @@ function mcpIdentity(): McpIdentity | null {
 
 switch (command) {
   case "install": {
-    installCodexHooks();
+    // Wire hooks to this script's absolute path so the Codex hook runner
+    // doesn't depend on `codex-honcho` being on PATH.
+    const self = fileURLToPath(import.meta.url);
+    installCodexHooks({ invoke: (verb) => `bun run ${JSON.stringify(self)} ${verb}` });
     console.log(`Installed Codex hooks → ${DEFAULT_HOOKS_PATH}`);
     console.log(`Enabled [features].hooks → ${DEFAULT_CONFIG_PATH}`);
     console.log(`Installed memory skill → ${installSkill()}`);

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$DIR"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun is required — install it from https://bun.sh, then re-run." >&2
+  exit 1
+fi
+
+echo "Installing dependencies…"
+bun install --silent
+
+if [ ! -f "$HOME/.honcho/config.json" ] && [ -z "${HONCHO_API_KEY:-}" ]; then
+  echo
+  echo "No Honcho config found. Set one up first:"
+  echo "  uv tool install honcho-cli && honcho init"
+  echo "Then re-run ./install.sh to register the MCP server."
+fi
+
+echo
+bun run "$DIR/bin/codex-honcho.ts" install
+echo
+echo "Done. Restart Codex (or start a new session) to load the hooks."

--- a/package.json
+++ b/package.json
@@ -14,9 +14,19 @@
   ],
   "author": "Plastic Labs",
   "license": "MIT",
+  "homepage": "https://honcho.dev",
+  "repository": "https://github.com/plastic-labs/codex-honcho",
   "bin": {
     "codex-honcho": "./bin/codex-honcho.ts"
   },
+  "files": [
+    "bin",
+    "src",
+    "skills",
+    "install.sh",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "test": "bun test",
     "typecheck": "tsc --noEmit"

--- a/skills/honcho-memory/SKILL.md
+++ b/skills/honcho-memory/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: honcho-memory
+description: Persistent cross-session memory via Honcho — recall what you know about the user before working, and save durable insights after.
+---
+
+# Honcho memory
+
+You have a persistent memory of this user that survives across sessions, backed by Honcho. The codex-honcho hooks already inject relevant context at the start of each turn, and they record the conversation automatically. This skill is for the times you should reach for memory *actively*.
+
+## When to pull memory
+
+Before non-trivial work, query memory instead of guessing:
+
+- The task touches the user's preferences, conventions, or past decisions
+- You're about to make an assumption you could instead verify ("which package manager?", "how is auth done here?")
+- The user references something from "before" or "last time"
+
+Use the Honcho MCP tools:
+
+- `search` — semantic lookup over past messages
+- `get_context` / `get_representation` — the current model of the user
+- `chat` — ask a natural-language question about the user ("what's their testing style?")
+
+## When to save memory
+
+After you learn something durable, persist it with `create_conclusion`:
+
+- A decision with rationale ("chose SQLite over Postgres — embedded, zero-setup")
+- A stable preference ("prefers small, focused PRs")
+- A non-obvious gotcha or root cause worth remembering
+- A convention specific to this codebase
+
+Keep each conclusion to one concise statement with the *why*. Review with `list_conclusions` before adding near-duplicates.
+
+## When not to bother
+
+Skip memory for throwaway or purely mechanical tasks — running a build, answering a general knowledge question, trivial edits. Don't narrate that you checked memory; just use it.

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,26 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const BIN = fileURLToPath(new URL("../bin/codex-honcho.ts", import.meta.url));
+
+// Codex blocks the turn until a hook command exits, and it ignores async:true.
+// So anything slow (uploads, dialectic) is re-run in a detached child and the
+// hook returns immediately. CODEX_HONCHO_BG marks the child so it doesn't
+// detach again.
+export function runDetached(verb: string, stdinText: string): void {
+  try {
+    const child = spawn("bun", ["run", BIN, verb], {
+      detached: true,
+      stdio: ["pipe", "ignore", "ignore"],
+      env: { ...process.env, CODEX_HONCHO_BG: "1" },
+    });
+    child.stdin.end(stdinText);
+    child.unref();
+  } catch {
+    // If the spawn fails, drop the work rather than block the turn.
+  }
+}
+
+export function isBackground(): boolean {
+  return process.env.CODEX_HONCHO_BG === "1";
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -6,7 +6,9 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 // the per-prompt hook (when enabled) can serve instantly without a network
 // round trip. lastInjected dedupes repeat injections.
 
-const CACHE_DIR = join(process.env.HONCHO_CONFIG_DIR || join(homedir(), ".honcho"), "codex", "context");
+function cacheDir(): string {
+  return join(process.env.HONCHO_CONFIG_DIR || join(homedir(), ".honcho"), "codex", "context");
+}
 
 export interface CachedContext {
   representation?: string | null;
@@ -16,7 +18,7 @@ export interface CachedContext {
 }
 
 function cachePath(key: string): string {
-  return join(CACHE_DIR, `${key.replace(/[^a-zA-Z0-9_-]/g, "_")}.json`);
+  return join(cacheDir(), `${key.replace(/[^a-zA-Z0-9_-]/g, "_")}.json`);
 }
 
 export function readContext(key: string): CachedContext | null {
@@ -28,7 +30,7 @@ export function readContext(key: string): CachedContext | null {
 }
 
 export function writeContext(key: string, representation?: string | null, peerCard?: string[] | null): void {
-  mkdirSync(CACHE_DIR, { recursive: true });
+  mkdirSync(cacheDir(), { recursive: true });
   const prev = readContext(key);
   writeFileSync(
     cachePath(key),
@@ -48,6 +50,6 @@ export function lastInjected(key: string): string | undefined {
 export function markInjected(key: string, text: string): void {
   const c = readContext(key);
   if (!c) return;
-  mkdirSync(CACHE_DIR, { recursive: true });
+  mkdirSync(cacheDir(), { recursive: true });
   writeFileSync(cachePath(key), JSON.stringify({ ...c, lastInjected: text }));
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,53 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+
+// Session-start context is cached so a resume/clear doesn't re-fetch, and so
+// the per-prompt hook (when enabled) can serve instantly without a network
+// round trip. lastInjected dedupes repeat injections.
+
+const CACHE_DIR = join(process.env.HONCHO_CONFIG_DIR || join(homedir(), ".honcho"), "codex", "context");
+
+export interface CachedContext {
+  representation?: string | null;
+  peerCard?: string[] | null;
+  at: number;
+  lastInjected?: string;
+}
+
+function cachePath(key: string): string {
+  return join(CACHE_DIR, `${key.replace(/[^a-zA-Z0-9_-]/g, "_")}.json`);
+}
+
+export function readContext(key: string): CachedContext | null {
+  try {
+    return JSON.parse(readFileSync(cachePath(key), "utf-8")) as CachedContext;
+  } catch {
+    return null;
+  }
+}
+
+export function writeContext(key: string, representation?: string | null, peerCard?: string[] | null): void {
+  mkdirSync(CACHE_DIR, { recursive: true });
+  const prev = readContext(key);
+  writeFileSync(
+    cachePath(key),
+    JSON.stringify({ representation, peerCard, at: Date.now(), lastInjected: prev?.lastInjected }),
+  );
+}
+
+export function isStale(key: string, ttlMs: number): boolean {
+  const c = readContext(key);
+  return !c || Date.now() - c.at > ttlMs;
+}
+
+export function lastInjected(key: string): string | undefined {
+  return readContext(key)?.lastInjected;
+}
+
+export function markInjected(key: string, text: string): void {
+  const c = readContext(key);
+  if (!c) return;
+  mkdirSync(CACHE_DIR, { recursive: true });
+  writeFileSync(cachePath(key), JSON.stringify({ ...c, lastInjected: text }));
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ interface HostBlock {
   enabled?: boolean;
   saveMessages?: boolean;
   reasoningLevel?: string;
+  injectPerPrompt?: boolean;
   endpoint?: { environment?: "production" | "local"; baseUrl?: string };
 }
 
@@ -43,6 +44,9 @@ export interface Config {
   enabled: boolean;
   saveMessages: boolean;
   reasoningLevel: string;
+  // Inject prompt-relevant context on every turn. Off by default — lean
+  // session-start context plus the MCP tools cover depth on demand.
+  injectPerPrompt: boolean;
   endpoint?: { environment?: "production" | "local"; baseUrl?: string };
   sessions?: Record<string, string>;
 }
@@ -83,6 +87,7 @@ export function loadConfig(): Config | null {
     enabled: (host?.enabled ?? raw.enabled) !== false,
     saveMessages: (host?.saveMessages ?? raw.saveMessages) !== false,
     reasoningLevel: host?.reasoningLevel ?? raw.reasoningLevel ?? "low",
+    injectPerPrompt: (host?.injectPerPrompt ?? raw.injectPerPrompt) === true,
     endpoint: host?.endpoint ?? raw.endpoint,
     sessions: raw.sessions,
   };
@@ -114,4 +119,10 @@ export function sessionName(config: Config, cwd: string): string {
   const override = config.sessions?.[cwd];
   if (override) return override;
   return `${slug(config.peerName)}-${slug(basename(cwd))}`;
+}
+
+// Stable key for cursor/cache files: the Codex session id when present, else
+// the derived session name.
+export function memoryKey(config: Config, cwd: string, sessionId?: string): string {
+  return sessionId || sessionName(config, cwd);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,11 +114,10 @@ function slug(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
 }
 
-// One stable session per project directory, prefixed with the peer name.
+// One stable session per project directory. No peer prefix — the workspace
+// already isolates a user's data, so the directory name alone is enough.
 export function sessionName(config: Config, cwd: string): string {
-  const override = config.sessions?.[cwd];
-  if (override) return override;
-  return `${slug(config.peerName)}-${slug(basename(cwd))}`;
+  return config.sessions?.[cwd] ?? slug(basename(cwd));
 }
 
 // Stable key for cursor/cache files: the Codex session id when present, else

--- a/src/connectors/codex.ts
+++ b/src/connectors/codex.ts
@@ -38,28 +38,30 @@ interface HooksFile {
 // How each verb maps onto a Codex event. Stop is turn-scoped (Codex has no
 // SessionEnd), so writeback runs every turn and ships only the new tail.
 function hookGroupsFor(invoke: (verb: HookVerb) => string): Record<string, HookGroup[]> {
+  // Only SessionStart carries a status label; the per-turn hooks run silently
+  // (and detached) to avoid spamming the UI every prompt and tool call.
   return {
     SessionStart: [
       {
         // Includes `compact` so memory is re-surfaced after a context reset.
         matcher: "startup|resume|clear|compact",
-        hooks: [{ type: "command", command: invoke("recall"), timeout: 30, statusMessage: "Recalling Honcho memory" }],
+        hooks: [{ type: "command", command: invoke("recall"), timeout: 30, statusMessage: "honcho" }],
       },
     ],
     UserPromptSubmit: [
       {
-        hooks: [{ type: "command", command: invoke("prompt"), timeout: 20, statusMessage: "Searching Honcho memory" }],
+        hooks: [{ type: "command", command: invoke("prompt"), timeout: 20 }],
       },
     ],
     PostToolUse: [
       {
         matcher: "*",
-        hooks: [{ type: "command", command: invoke("observe"), timeout: 10, statusMessage: "Recording Honcho context" }],
+        hooks: [{ type: "command", command: invoke("observe"), timeout: 10 }],
       },
     ],
     Stop: [
       {
-        hooks: [{ type: "command", command: invoke("writeback"), timeout: 30, statusMessage: "Saving Honcho memory" }],
+        hooks: [{ type: "command", command: invoke("writeback"), timeout: 30 }],
       },
     ],
     // Flush the conversation before compaction discards it; the cursor keeps
@@ -67,7 +69,7 @@ function hookGroupsFor(invoke: (verb: HookVerb) => string): Record<string, HookG
     PreCompact: [
       {
         matcher: "manual|auto",
-        hooks: [{ type: "command", command: invoke("writeback"), timeout: 30, statusMessage: "Flushing Honcho memory" }],
+        hooks: [{ type: "command", command: invoke("writeback"), timeout: 30 }],
       },
     ],
   };

--- a/src/connectors/codex.ts
+++ b/src/connectors/codex.ts
@@ -6,8 +6,13 @@ import { homedir } from "node:os";
 // feature is switched on in ~/.codex/config.toml. We own four events; the
 // installer merges them in additively and never touches a user's own hooks.
 
-export const DEFAULT_HOOKS_PATH = join(homedir(), ".codex", "hooks.json");
-export const DEFAULT_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
+// CODEX_HOME mirrors Codex's own env override and keeps paths injectable.
+export function codexHome(): string {
+  return process.env.CODEX_HOME || join(homedir(), ".codex");
+}
+
+export const DEFAULT_HOOKS_PATH = join(codexHome(), "hooks.json");
+export const DEFAULT_CONFIG_PATH = join(codexHome(), "config.toml");
 
 // Our own dispatch verbs — the codex-honcho entrypoint routes each to a handler.
 export const HOOK_VERBS = ["recall", "prompt", "observe", "writeback"] as const;

--- a/src/connectors/codex.ts
+++ b/src/connectors/codex.ts
@@ -36,7 +36,8 @@ function hookGroupsFor(invoke: (verb: HookVerb) => string): Record<string, HookG
   return {
     SessionStart: [
       {
-        matcher: "startup|resume|clear",
+        // Includes `compact` so memory is re-surfaced after a context reset.
+        matcher: "startup|resume|clear|compact",
         hooks: [{ type: "command", command: invoke("recall"), timeout: 30, statusMessage: "Recalling Honcho memory" }],
       },
     ],
@@ -54,6 +55,14 @@ function hookGroupsFor(invoke: (verb: HookVerb) => string): Record<string, HookG
     Stop: [
       {
         hooks: [{ type: "command", command: invoke("writeback"), timeout: 30, statusMessage: "Saving Honcho memory" }],
+      },
+    ],
+    // Flush the conversation before compaction discards it; the cursor keeps
+    // this from duplicating what Stop already shipped.
+    PreCompact: [
+      {
+        matcher: "manual|auto",
+        hooks: [{ type: "command", command: invoke("writeback"), timeout: 30, statusMessage: "Flushing Honcho memory" }],
       },
     ],
   };

--- a/src/connectors/mcp.ts
+++ b/src/connectors/mcp.ts
@@ -1,0 +1,78 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { DEFAULT_CONFIG_PATH } from "./codex.ts";
+
+// Honcho runs a hosted MCP server at https://mcp.honcho.dev. Rather than ship
+// our own, we register it in ~/.codex/config.toml so Codex gets the active
+// recall tools (search/chat/get_context/...). Auth + identity ride in headers.
+
+export const HONCHO_MCP_URL = "https://mcp.honcho.dev";
+
+// We own a fenced region of config.toml so we can rewrite/remove it cleanly
+// without parsing the whole TOML document.
+const BLOCK_START = "# >>> codex-honcho (honcho mcp) >>>";
+const BLOCK_END = "# <<< codex-honcho (honcho mcp) <<<";
+
+export interface McpIdentity {
+  apiKey: string;
+  userName: string;
+  workspaceId?: string;
+  assistantName?: string;
+}
+
+function buildBlock(id: McpIdentity): string {
+  const headers = [`Authorization:Bearer ${id.apiKey}`, `X-Honcho-User-Name:${id.userName}`];
+  if (id.workspaceId) headers.push(`X-Honcho-Workspace-ID:${id.workspaceId}`);
+  if (id.assistantName) headers.push(`X-Honcho-Assistant-Name:${id.assistantName}`);
+
+  const args = ["-y", "mcp-remote", HONCHO_MCP_URL];
+  for (const h of headers) args.push("--header", h);
+  const argsToml = args.map((a) => JSON.stringify(a)).join(", ");
+
+  return [
+    BLOCK_START,
+    "[mcp_servers.honcho]",
+    'command = "npx"',
+    `args = [${argsToml}]`,
+    BLOCK_END,
+  ].join("\n");
+}
+
+function stripBlock(content: string): string {
+  const start = content.indexOf(BLOCK_START);
+  if (start === -1) return content;
+  const end = content.indexOf(BLOCK_END, start);
+  if (end === -1) return content;
+  const before = content.slice(0, start).replace(/\n*$/, "");
+  const after = content.slice(end + BLOCK_END.length).replace(/^\n*/, "");
+  return [before, after].filter(Boolean).join("\n\n") + (after ? "" : "\n");
+}
+
+// Replace any existing block with a fresh one; idempotent.
+export function setMcpServer(content: string, id: McpIdentity): string {
+  const base = stripBlock(content).trimEnd();
+  const block = buildBlock(id);
+  return base ? `${base}\n\n${block}\n` : `${block}\n`;
+}
+
+export function clearMcpServer(content: string): string {
+  return stripBlock(content).trimEnd() + "\n";
+}
+
+export function hasMcpServer(content: string): boolean {
+  return content.includes(BLOCK_START);
+}
+
+export function installMcpServer(id: McpIdentity, configPath: string = DEFAULT_CONFIG_PATH): void {
+  mkdirSync(dirname(configPath), { recursive: true });
+  const existing = existsSync(configPath) ? readFileSync(configPath, "utf-8") : "";
+  writeFileSync(configPath, setMcpServer(existing, id));
+}
+
+export function removeMcpServer(configPath: string = DEFAULT_CONFIG_PATH): boolean {
+  if (!existsSync(configPath)) return false;
+  const existing = readFileSync(configPath, "utf-8");
+  if (!hasMcpServer(existing)) return false;
+  writeFileSync(configPath, clearMcpServer(existing));
+  return true;
+}

--- a/src/connectors/skill.ts
+++ b/src/connectors/skill.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, copyFileSync, rmSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { codexHome } from "./codex.ts";
 
 // Codex discovers agent skills under ~/.codex/skills/<name>/SKILL.md. We ship
 // one that tells the model when to actively query and save Honcho memory.
@@ -10,7 +10,7 @@ const SKILL_NAME = "honcho-memory";
 const SKILL_SOURCE = fileURLToPath(new URL("../../skills/honcho-memory/SKILL.md", import.meta.url));
 
 function defaultSkillsDir(): string {
-  return join(homedir(), ".codex", "skills");
+  return join(codexHome(), "skills");
 }
 
 export function installSkill(skillsDir: string = defaultSkillsDir()): string {

--- a/src/connectors/skill.ts
+++ b/src/connectors/skill.ts
@@ -1,0 +1,32 @@
+import { existsSync, mkdirSync, copyFileSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+// Codex discovers agent skills under ~/.codex/skills/<name>/SKILL.md. We ship
+// one that tells the model when to actively query and save Honcho memory.
+
+const SKILL_NAME = "honcho-memory";
+const SKILL_SOURCE = fileURLToPath(new URL("../../skills/honcho-memory/SKILL.md", import.meta.url));
+
+function defaultSkillsDir(): string {
+  return join(homedir(), ".codex", "skills");
+}
+
+export function installSkill(skillsDir: string = defaultSkillsDir()): string {
+  const dest = join(skillsDir, SKILL_NAME, "SKILL.md");
+  mkdirSync(dirname(dest), { recursive: true });
+  copyFileSync(SKILL_SOURCE, dest);
+  return dest;
+}
+
+export function removeSkill(skillsDir: string = defaultSkillsDir()): boolean {
+  const dir = join(skillsDir, SKILL_NAME);
+  if (!existsSync(dir)) return false;
+  rmSync(dir, { recursive: true, force: true });
+  return true;
+}
+
+export function hasSkill(skillsDir: string = defaultSkillsDir()): boolean {
+  return existsSync(join(skillsDir, SKILL_NAME, "SKILL.md"));
+}

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -7,11 +7,13 @@ import type { Turn } from "./transcript/codex.ts";
 // repeatedly over a growing rollout. The cursor records how many turns we've
 // already shipped for a session, so each Stop uploads only the new tail.
 
-const CURSOR_DIR = join(homedir(), ".honcho", "codex", "cursors");
+function cursorDir(): string {
+  return join(process.env.HONCHO_CONFIG_DIR || join(homedir(), ".honcho"), "codex", "cursors");
+}
 
 function cursorPath(sessionId: string): string {
   const safe = sessionId.replace(/[^a-zA-Z0-9_-]/g, "_");
-  return join(CURSOR_DIR, `${safe}.json`);
+  return join(cursorDir(), `${safe}.json`);
 }
 
 export function readCursor(sessionId: string): number {
@@ -24,7 +26,7 @@ export function readCursor(sessionId: string): number {
 }
 
 export function writeCursor(sessionId: string, count: number): void {
-  mkdirSync(CURSOR_DIR, { recursive: true });
+  mkdirSync(cursorDir(), { recursive: true });
   writeFileSync(cursorPath(sessionId), JSON.stringify({ count, at: new Date().toISOString() }));
 }
 

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -1,7 +1,7 @@
 import { HOOK_VERBS, type HookVerb } from "./connectors/codex.ts";
 
 // Verbs that aren't Codex events — only ever spawned detached by a handler.
-export const INTERNAL_VERBS = ["dialectic"] as const;
+export const INTERNAL_VERBS = ["dialectic", "flush"] as const;
 export type Verb = HookVerb | (typeof INTERNAL_VERBS)[number];
 
 export function isHookVerb(value: string): value is HookVerb {
@@ -43,6 +43,10 @@ export async function dispatch(verb: Verb, stdinText: string): Promise<string> {
       case "dialectic": {
         const { dialectic } = await import("./hooks/dialectic.ts");
         return await dialectic(input);
+      }
+      case "flush": {
+        const { flush } = await import("./hooks/flush.ts");
+        return await flush(input);
       }
     }
   } catch {

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -1,12 +1,20 @@
 import { HOOK_VERBS, type HookVerb } from "./connectors/codex.ts";
 
+// Verbs that aren't Codex events — only ever spawned detached by a handler.
+export const INTERNAL_VERBS = ["dialectic"] as const;
+export type Verb = HookVerb | (typeof INTERNAL_VERBS)[number];
+
 export function isHookVerb(value: string): value is HookVerb {
   return (HOOK_VERBS as readonly string[]).includes(value);
 }
 
+export function isVerb(value: string): value is Verb {
+  return isHookVerb(value) || (INTERNAL_VERBS as readonly string[]).includes(value);
+}
+
 // Route a hook verb to its handler. Every handler is best-effort: any failure
 // resolves to an empty string so a hook never blocks or breaks a Codex turn.
-export async function dispatch(verb: HookVerb, stdinText: string): Promise<string> {
+export async function dispatch(verb: Verb, stdinText: string): Promise<string> {
   let input: Record<string, unknown> = {};
   try {
     input = JSON.parse(stdinText || "{}");
@@ -31,6 +39,10 @@ export async function dispatch(verb: HookVerb, stdinText: string): Promise<strin
       case "writeback": {
         const { writeback } = await import("./hooks/writeback.ts");
         return await writeback(input);
+      }
+      case "dialectic": {
+        const { dialectic } = await import("./hooks/dialectic.ts");
+        return await dialectic(input);
       }
     }
   } catch {

--- a/src/hooks/dialectic.ts
+++ b/src/hooks/dialectic.ts
@@ -1,0 +1,31 @@
+import { loadConfig, sessionName } from "../config.ts";
+import { openSession } from "../memory.ts";
+
+interface DialecticInput {
+  cwd?: string;
+  session_id?: string;
+}
+
+// Background worker (spawned detached by recall): nudges Honcho's dialectic
+// engine so its representation of the user keeps improving. Results are
+// discarded — the value is the server-side reasoning it triggers.
+export async function dialectic(input: DialecticInput): Promise<string> {
+  const config = loadConfig();
+  if (!config || !config.enabled || config.reasoningLevel === "minimal") return "";
+
+  const cwd = input.cwd || process.cwd();
+  const name = sessionName(config, cwd);
+  const { session, userPeer } = await openSession(config, name);
+
+  await Promise.allSettled([
+    userPeer.chat(
+      `Summarize what you know about ${config.peerName} — preferences, current projects, and working style.`,
+      { session, reasoningLevel: config.reasoningLevel },
+    ),
+    userPeer.chat(`What has ${config.peerName} been working on recently?`, {
+      session,
+      reasoningLevel: config.reasoningLevel,
+    }),
+  ]);
+  return "";
+}

--- a/src/hooks/flush.ts
+++ b/src/hooks/flush.ts
@@ -1,0 +1,83 @@
+import { join } from "node:path";
+import { mkdirSync, writeFileSync, unlinkSync, readFileSync } from "node:fs";
+import { loadConfig, sessionName, memoryKey } from "../config.ts";
+import { openSession } from "../memory.ts";
+import { readQueue, sentCount, setSentCount, queueDir } from "../queue.ts";
+
+interface FlushInput {
+  cwd?: string;
+  session_id?: string;
+}
+
+const MAX_CHARS = 4000;
+
+function lockPath(key: string): string {
+  return join(queueDir(), `${key.replace(/[^a-zA-Z0-9_-]/g, "_")}.lock`);
+}
+
+// Single-flusher lock: skip if another flush holds it (dead owners are taken
+// over). Prevents two concurrent flushes from double-sending the same entries.
+function acquireLock(key: string): boolean {
+  const path = lockPath(key);
+  try {
+    mkdirSync(queueDir(), { recursive: true });
+    writeFileSync(path, String(process.pid), { flag: "wx" });
+    return true;
+  } catch {
+    try {
+      const owner = parseInt(readFileSync(path, "utf-8").trim(), 10);
+      process.kill(owner, 0); // throws if the owner is gone
+      return false;
+    } catch {
+      try {
+        writeFileSync(path, String(process.pid));
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+}
+
+function releaseLock(key: string): void {
+  try {
+    unlinkSync(lockPath(key));
+  } catch {
+    // already gone
+  }
+}
+
+// Background worker: drain pending queue entries to Honcho, in order, and
+// advance the sent marker only on success so failures retry next time.
+export async function flush(input: FlushInput): Promise<string> {
+  const config = loadConfig();
+  if (!config || !config.enabled || !config.saveMessages) return "";
+
+  const cwd = input.cwd || process.cwd();
+  const name = sessionName(config, cwd);
+  const key = memoryKey(config, cwd, input.session_id);
+
+  if (!acquireLock(key)) return "";
+  try {
+    const all = readQueue(key);
+    const start = sentCount(key);
+    const batch = all.slice(start);
+    if (batch.length === 0) return "";
+
+    const { session, userPeer, aiPeer } = await openSession(config, name);
+    const messages = batch.map((entry) => {
+      const peer = entry.role === "user" ? userPeer : aiPeer;
+      const text = entry.role === "tool" ? `[tool] ${entry.text}` : entry.text;
+      return peer.message(text.slice(0, MAX_CHARS), {
+        createdAt: entry.at,
+        ...(entry.role === "tool" ? { metadata: { type: "tool" } } : {}),
+      });
+    });
+
+    await session.addMessages(messages);
+    setSentCount(key, start + batch.length);
+  } finally {
+    releaseLock(key);
+  }
+  return "";
+}

--- a/src/hooks/observe.ts
+++ b/src/hooks/observe.ts
@@ -22,6 +22,10 @@ function shellCommand(input: Record<string, unknown>): string {
 export function summarizeTool(name: string, input: Record<string, unknown>): string {
   if (!name) return "";
 
+  // Don't record Honcho's own MCP calls — recording that we queried memory is
+  // circular noise that pollutes the representation.
+  if (name.startsWith("mcp__honcho")) return "";
+
   if (name === "shell" || name === "local_shell" || name === "exec") {
     const cmd = shellCommand(input).trim();
     if (!cmd) return "";

--- a/src/hooks/observe.ts
+++ b/src/hooks/observe.ts
@@ -1,11 +1,13 @@
-import { loadConfig, sessionName } from "../config.ts";
-import { openSession } from "../memory.ts";
+import { loadConfig, memoryKey } from "../config.ts";
+import { enqueue } from "../queue.ts";
+import { runDetached } from "../background.ts";
 
 interface ObserveInput {
   tool_name?: string;
   tool_input?: Record<string, unknown>;
   tool_response?: unknown;
   cwd?: string;
+  session_id?: string;
 }
 
 // Skip read-only/navigation shell commands that carry no memory signal.
@@ -43,7 +45,8 @@ export function summarizeTool(name: string, input: Record<string, unknown>): str
   return `used ${name}`;
 }
 
-// PostToolUse: record a terse observation of meaningful tool activity.
+// PostToolUse: queue a terse observation of meaningful tool activity, then kick
+// a background flush. Local + instant; the upload happens async.
 export async function observe(input: ObserveInput): Promise<string> {
   const config = loadConfig();
   if (!config || !config.enabled || !config.saveMessages) return "";
@@ -52,8 +55,8 @@ export async function observe(input: ObserveInput): Promise<string> {
   if (!summary) return "";
 
   const cwd = input.cwd || process.cwd();
-  const name = sessionName(config, cwd);
-  const { session, aiPeer } = await openSession(config, name);
-  await session.addMessages([aiPeer.message(`[tool] ${summary}`, { metadata: { type: "tool" } })]);
+  const key = memoryKey(config, cwd, input.session_id);
+  enqueue(key, [{ role: "tool", text: summary, at: new Date().toISOString() }]);
+  runDetached("flush", JSON.stringify({ cwd, session_id: input.session_id }));
   return "";
 }

--- a/src/hooks/observe.ts
+++ b/src/hooks/observe.ts
@@ -50,6 +50,6 @@ export async function observe(input: ObserveInput): Promise<string> {
   const cwd = input.cwd || process.cwd();
   const name = sessionName(config, cwd);
   const { session, aiPeer } = await openSession(config, name);
-  await session.addMessages([aiPeer.message(`[tool] ${summary}`, { metadata: { type: "tool", session_affinity: name } })]);
+  await session.addMessages([aiPeer.message(`[tool] ${summary}`, { metadata: { type: "tool" } })]);
   return "";
 }

--- a/src/hooks/prompt.ts
+++ b/src/hooks/prompt.ts
@@ -1,5 +1,6 @@
-import { loadConfig, sessionName } from "../config.ts";
-import { openSession, renderContext } from "../memory.ts";
+import { loadConfig, sessionName, memoryKey } from "../config.ts";
+import { renderContext } from "../memory.ts";
+import { readContext, lastInjected, markInjected } from "../cache.ts";
 
 interface PromptInput {
   prompt?: string;
@@ -9,24 +10,25 @@ interface PromptInput {
 
 const TRIVIAL = /^(y|n|yes|no|ok|okay|sure|thanks|yep|nope|continue|go ahead|do it|proceed)\.?$/i;
 
-// UserPromptSubmit: pull context relevant to this prompt and inject it.
+// UserPromptSubmit: off by default — session-start context plus the MCP tools
+// cover recall without taxing every turn. When injectPerPrompt is enabled,
+// serve the cached snapshot (no network) and never repeat the same block.
 export async function prompt(input: PromptInput): Promise<string> {
   const config = loadConfig();
-  if (!config || !config.enabled) return "";
+  if (!config || !config.enabled || !config.injectPerPrompt) return "";
 
   const text = (input.prompt ?? "").trim();
   if (!text || TRIVIAL.test(text)) return "";
 
   const cwd = input.cwd || process.cwd();
-  const name = sessionName(config, cwd);
+  const key = memoryKey(config, cwd, input.session_id);
 
-  const { userPeer } = await openSession(config, name);
-  const context = await userPeer.context({
-    searchQuery: text,
-    searchTopK: 5,
-    searchMaxDistance: 0.7,
-    maxConclusions: 10,
-    includeMostFrequent: true,
-  });
-  return renderContext(context, config.peerName);
+  const cached = readContext(key);
+  if (!cached) return "";
+
+  const block = renderContext(cached, config.peerName, 5);
+  if (!block || block === lastInjected(key)) return "";
+
+  markInjected(key, block);
+  return block;
 }

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -6,7 +6,14 @@ interface RecallInput {
   session_id?: string;
 }
 
-// SessionStart: materialize the session and surface what we know about the user.
+// Injected once at session start so the model actively queries memory through
+// the Honcho MCP tools rather than relying only on this passive context.
+const TOOL_HINT =
+  "Honcho memory tools are available via MCP — call honcho search / get_context to recall facts " +
+  "across sessions, and honcho chat for questions about the user's history. Prefer querying over guessing.";
+
+// SessionStart: materialize the session, surface what we know, and nudge the
+// dialectic engine so its reasoning keeps feeding the knowledge graph.
 export async function recall(input: RecallInput): Promise<string> {
   const config = loadConfig();
   if (!config || !config.enabled) return "";
@@ -14,7 +21,24 @@ export async function recall(input: RecallInput): Promise<string> {
   const cwd = input.cwd || process.cwd();
   const name = sessionName(config, cwd);
 
-  const { userPeer } = await openSession(config, name);
+  const { session, userPeer } = await openSession(config, name);
   const context = await userPeer.context({ maxConclusions: 20, includeMostFrequent: true });
-  return renderContext(context, config.peerName);
+
+  // Dialectic reasoning, bounded and best-effort: results aren't displayed, but
+  // running them refines Honcho's representation of the user over time.
+  if (config.reasoningLevel !== "minimal") {
+    await Promise.allSettled([
+      userPeer.chat(
+        `Summarize what you know about ${config.peerName} — preferences, current projects, and working style.`,
+        { session, reasoningLevel: config.reasoningLevel },
+      ),
+      userPeer.chat(`What has ${config.peerName} been working on recently?`, {
+        session,
+        reasoningLevel: config.reasoningLevel,
+      }),
+    ]);
+  }
+
+  const block = renderContext(context, config.peerName);
+  return block ? `${block}\n${TOOL_HINT}` : TOOL_HINT;
 }

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -1,44 +1,49 @@
-import { loadConfig, sessionName } from "../config.ts";
+import { loadConfig, sessionName, memoryKey } from "../config.ts";
 import { openSession, renderContext } from "../memory.ts";
+import { readContext, writeContext, isStale, markInjected } from "../cache.ts";
+import { runDetached } from "../background.ts";
 
 interface RecallInput {
   cwd?: string;
   session_id?: string;
 }
 
+const CACHE_TTL_MS = 10 * 60 * 1000;
+const MAX_CONCLUSIONS = 8;
+
 // Injected once at session start so the model actively queries memory through
-// the Honcho MCP tools rather than relying only on this passive context.
+// the Honcho MCP tools rather than leaning on heavy per-turn injection.
 const TOOL_HINT =
   "Honcho memory tools are available via MCP — call honcho search / get_context to recall facts " +
   "across sessions, and honcho chat for questions about the user's history. Prefer querying over guessing.";
 
-// SessionStart: materialize the session, surface what we know, and nudge the
-// dialectic engine so its reasoning keeps feeding the knowledge graph.
+// SessionStart: materialize the session, surface a lean snapshot, and kick the
+// dialectic engine in the background so it keeps refining Honcho's model.
 export async function recall(input: RecallInput): Promise<string> {
   const config = loadConfig();
   if (!config || !config.enabled) return "";
 
   const cwd = input.cwd || process.cwd();
   const name = sessionName(config, cwd);
+  const key = memoryKey(config, cwd, input.session_id);
 
-  const { session, userPeer } = await openSession(config, name);
-  const context = await userPeer.context({ maxConclusions: 20, includeMostFrequent: true });
+  // openSession also materializes peers, which writeback relies on.
+  const { userPeer } = await openSession(config, name);
 
-  // Dialectic reasoning, bounded and best-effort: results aren't displayed, but
-  // running them refines Honcho's representation of the user over time.
-  if (config.reasoningLevel !== "minimal") {
-    await Promise.allSettled([
-      userPeer.chat(
-        `Summarize what you know about ${config.peerName} — preferences, current projects, and working style.`,
-        { session, reasoningLevel: config.reasoningLevel },
-      ),
-      userPeer.chat(`What has ${config.peerName} been working on recently?`, {
-        session,
-        reasoningLevel: config.reasoningLevel,
-      }),
-    ]);
+  let ctx = !isStale(key, CACHE_TTL_MS) ? readContext(key) : null;
+  if (!ctx) {
+    const fetched = await userPeer.context({ maxConclusions: MAX_CONCLUSIONS, includeMostFrequent: true });
+    writeContext(key, fetched.representation, fetched.peerCard);
+    ctx = { representation: fetched.representation, peerCard: fetched.peerCard, at: Date.now() };
   }
 
-  const block = renderContext(context, config.peerName);
+  // Dialectic feeds the knowledge graph but is slow — run it detached so it
+  // never blocks the session opening.
+  if (config.reasoningLevel !== "minimal") {
+    runDetached("dialectic", JSON.stringify({ cwd, session_id: input.session_id }));
+  }
+
+  const block = renderContext(ctx, config.peerName, 5);
+  if (block) markInjected(key, block);
   return block ? `${block}\n${TOOL_HINT}` : TOOL_HINT;
 }

--- a/src/hooks/writeback.ts
+++ b/src/hooks/writeback.ts
@@ -1,7 +1,8 @@
-import { loadConfig, sessionName } from "../config.ts";
-import { openSession } from "../memory.ts";
+import { loadConfig, sessionName, memoryKey } from "../config.ts";
 import { readRollout } from "../transcript/codex.ts";
 import { readCursor, writeCursor, selectNewTurns } from "../cursor.ts";
+import { enqueue } from "../queue.ts";
+import { runDetached } from "../background.ts";
 
 interface WritebackInput {
   session_id?: string;
@@ -9,29 +10,29 @@ interface WritebackInput {
   transcript_path?: string;
 }
 
-const MAX_CHARS = 4000;
+// Pure-local: pull the rollout turns not yet captured into the queue and
+// advance the rollout cursor. No network — returns how many were enqueued.
+export function capture(key: string, rolloutPath: string): number {
+  const turns = readRollout(rolloutPath);
+  const { fresh, nextCursor } = selectNewTurns(turns, readCursor(key));
+  if (fresh.length === 0) return 0;
+  enqueue(key, fresh.map((t) => ({ role: t.role, text: t.text, at: t.at })));
+  writeCursor(key, nextCursor);
+  return fresh.length;
+}
 
-// Stop (turn-scoped): ship the turns added since the last writeback.
+// Stop / PreCompact (turn-scoped): capture this turn's new rollout tail into
+// the queue instantly, then kick a background flush. The upload never blocks.
 export async function writeback(input: WritebackInput): Promise<string> {
   const config = loadConfig();
   if (!config || !config.enabled || !config.saveMessages) return "";
   if (!input.transcript_path) return "";
 
   const cwd = input.cwd || process.cwd();
-  const name = sessionName(config, cwd);
-  const cursorKey = input.session_id || name;
+  const key = memoryKey(config, cwd, input.session_id);
 
-  const turns = readRollout(input.transcript_path);
-  const { fresh, nextCursor } = selectNewTurns(turns, readCursor(cursorKey));
-  if (fresh.length === 0) return "";
-
-  const { session, userPeer, aiPeer } = await openSession(config, name);
-  const messages = fresh.map((turn) => {
-    const peer = turn.role === "user" ? userPeer : aiPeer;
-    return peer.message(turn.text.slice(0, MAX_CHARS), { createdAt: turn.at });
-  });
-
-  await session.addMessages(messages);
-  writeCursor(cursorKey, nextCursor);
+  if (capture(key, input.transcript_path) > 0) {
+    runDetached("flush", JSON.stringify({ cwd, session_id: input.session_id }));
+  }
   return "";
 }

--- a/src/hooks/writeback.ts
+++ b/src/hooks/writeback.ts
@@ -28,10 +28,7 @@ export async function writeback(input: WritebackInput): Promise<string> {
   const { session, userPeer, aiPeer } = await openSession(config, name);
   const messages = fresh.map((turn) => {
     const peer = turn.role === "user" ? userPeer : aiPeer;
-    return peer.message(turn.text.slice(0, MAX_CHARS), {
-      createdAt: turn.at,
-      metadata: { session_affinity: name },
-    });
+    return peer.message(turn.text.slice(0, MAX_CHARS), { createdAt: turn.at });
   });
 
   await session.addMessages(messages);

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,0 +1,70 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from "node:fs";
+
+// A durable, human-readable outbox. Capture hooks append here instantly (local,
+// no network) so everything recorded is visible live (`tail -f`); a background
+// flush drains pending entries to Honcho and advances a sent high-water-mark.
+// Unsent entries stay put and retry on the next flush.
+
+export function queueDir(): string {
+  return join(process.env.HONCHO_CONFIG_DIR || join(homedir(), ".honcho"), "codex", "queue");
+}
+
+export interface QueueEntry {
+  role: "user" | "assistant" | "tool";
+  text: string;
+  at?: string;
+}
+
+function safe(key: string): string {
+  return key.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function queuePath(key: string): string {
+  return join(queueDir(), `${safe(key)}.jsonl`);
+}
+
+function sentPath(key: string): string {
+  return join(queueDir(), `${safe(key)}.sent`);
+}
+
+export function enqueue(key: string, entries: QueueEntry[]): void {
+  if (entries.length === 0) return;
+  mkdirSync(queueDir(), { recursive: true });
+  appendFileSync(queuePath(key), entries.map((e) => JSON.stringify(e)).join("\n") + "\n");
+}
+
+export function readQueue(key: string): QueueEntry[] {
+  try {
+    return readFileSync(queuePath(key), "utf-8")
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l) as QueueEntry);
+  } catch {
+    return [];
+  }
+}
+
+export function sentCount(key: string): number {
+  try {
+    const n = parseInt(readFileSync(sentPath(key), "utf-8").trim(), 10);
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function setSentCount(key: string, n: number): void {
+  mkdirSync(queueDir(), { recursive: true });
+  writeFileSync(sentPath(key), String(n));
+}
+
+// Entries captured but not yet confirmed sent to Honcho.
+export function pending(key: string): QueueEntry[] {
+  return readQueue(key).slice(sentCount(key));
+}
+
+export function pendingCount(key: string): number {
+  return Math.max(0, readQueue(key).length - sentCount(key));
+}

--- a/src/transcript/codex.ts
+++ b/src/transcript/codex.ts
@@ -33,6 +33,24 @@ interface RolloutEvent {
 
 const TEXT_BLOCK_TYPES = new Set(["input_text", "output_text", "text"]);
 
+// Codex injects its own context as user-role messages (environment, instruction
+// blobs, abort markers). These aren't things the user said, so they're dropped
+// from what we persist to Honcho.
+const CODEX_SYSTEM_TAGS = [
+  "environment_context",
+  "turn_aborted",
+  "user_instructions",
+  "apps_instructions",
+  "plugins_instructions",
+  "skills_instructions",
+  "collaboration_mode",
+];
+
+function isInjectedSystemTurn(text: string): boolean {
+  const t = text.trimStart();
+  return CODEX_SYSTEM_TAGS.some((tag) => t.startsWith(`<${tag}>`) || t.startsWith(`<${tag} `));
+}
+
 function collectText(content: string | ContentBlock[] | undefined): string {
   if (typeof content === "string") return content.trim();
   if (!Array.isArray(content)) return "";
@@ -72,6 +90,7 @@ export function readRollout(path: string): Turn[] {
 
     const text = collectText(payload.content);
     if (!text) continue;
+    if (payload.role === "user" && isInjectedSystemTurn(text)) continue;
 
     turns.push({ role: payload.role, text, at: event.timestamp });
   }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -70,10 +70,10 @@ test("globalOverride applies flat fields across hosts", () => {
   expect(loadConfig()!.workspace).toBe("flat-ws");
 });
 
-test("session name is peer-prefixed and slugged per directory", () => {
+test("session name is the slugged directory, no peer prefix", () => {
   writeConfig({ apiKey: "k", peerName: "Eri" });
   const cfg = loadConfig()!;
-  expect(sessionName(cfg, "/Users/eri/My Project")).toBe("eri-my-project");
+  expect(sessionName(cfg, "/Users/eri/My Project")).toBe("my-project");
 });
 
 test("explicit session override wins", () => {

--- a/test/connectors/codex.test.ts
+++ b/test/connectors/codex.test.ts
@@ -18,13 +18,16 @@ function readJson(path: string) {
   return JSON.parse(readFileSync(path, "utf-8"));
 }
 
-test("install writes our four events", () => {
+test("install writes our hook events", () => {
   const { hooks, config } = tmp();
   installCodexHooks({ hooksPath: hooks, configPath: config });
   const file = readJson(hooks);
-  expect(Object.keys(file.hooks).sort()).toEqual(["PostToolUse", "SessionStart", "Stop", "UserPromptSubmit"]);
+  expect(Object.keys(file.hooks).sort()).toEqual(["PostToolUse", "PreCompact", "SessionStart", "Stop", "UserPromptSubmit"]);
   expect(file.hooks.Stop[0].hooks[0].command).toContain("writeback");
-  expect(file.hooks.SessionStart[0].matcher).toBe("startup|resume|clear");
+  expect(file.hooks.SessionStart[0].matcher).toBe("startup|resume|clear|compact");
+  // PreCompact reuses the writeback verb to flush before a context reset.
+  expect(file.hooks.PreCompact[0].hooks[0].command).toContain("writeback");
+  expect(file.hooks.PreCompact[0].matcher).toBe("manual|auto");
 });
 
 test("install enables the hooks feature flag", () => {

--- a/test/connectors/mcp.test.ts
+++ b/test/connectors/mcp.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "bun:test";
+import { setMcpServer, clearMcpServer, hasMcpServer, HONCHO_MCP_URL } from "../../src/connectors/mcp.ts";
+
+const id = { apiKey: "hch-secret", userName: "eri", workspaceId: "codex", assistantName: "codex" };
+
+test("setMcpServer writes a honcho mcp block with creds and headers", () => {
+  const out = setMcpServer("", id);
+  expect(out).toContain("[mcp_servers.honcho]");
+  expect(out).toContain(HONCHO_MCP_URL);
+  expect(out).toContain("Authorization:Bearer hch-secret");
+  expect(out).toContain("X-Honcho-User-Name:eri");
+  expect(out).toContain("X-Honcho-Workspace-ID:codex");
+  expect(hasMcpServer(out)).toBe(true);
+});
+
+test("optional headers are omitted when absent", () => {
+  const out = setMcpServer("", { apiKey: "k", userName: "eri" });
+  expect(out).not.toContain("X-Honcho-Workspace-ID");
+  expect(out).not.toContain("X-Honcho-Assistant-Name");
+});
+
+test("setMcpServer is idempotent — one block after repeated writes", () => {
+  let out = setMcpServer("", id);
+  out = setMcpServer(out, id);
+  out = setMcpServer(out, { ...id, apiKey: "hch-rotated" });
+  expect(out.match(/\[mcp_servers\.honcho\]/g)).toHaveLength(1);
+  // Latest creds win.
+  expect(out).toContain("hch-rotated");
+  expect(out).not.toContain("hch-secret");
+});
+
+test("preserves the user's surrounding config", () => {
+  const base = 'model = "o3"\n\n[features]\nhooks = true\n';
+  const out = setMcpServer(base, id);
+  expect(out).toContain('model = "o3"');
+  expect(out).toContain("[features]");
+  expect(out).toContain("[mcp_servers.honcho]");
+});
+
+test("clearMcpServer removes only our block", () => {
+  const base = 'model = "o3"\n';
+  const withBlock = setMcpServer(base, id);
+  const cleared = clearMcpServer(withBlock);
+  expect(hasMcpServer(cleared)).toBe(false);
+  expect(cleared).toContain('model = "o3"');
+});
+
+test("clear on a file without our block is a harmless passthrough", () => {
+  const base = "model = \"o3\"\n";
+  expect(hasMcpServer(clearMcpServer(base))).toBe(false);
+  expect(clearMcpServer(base)).toContain("model");
+});

--- a/test/connectors/skill.test.ts
+++ b/test/connectors/skill.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { installSkill, removeSkill, hasSkill } from "../../src/connectors/skill.ts";
+
+function tmpSkills(): string {
+  return mkdtempSync(join(tmpdir(), "codex-honcho-skills-"));
+}
+
+test("installSkill writes the honcho-memory SKILL.md", () => {
+  const dir = tmpSkills();
+  const dest = installSkill(dir);
+  expect(dest).toBe(join(dir, "honcho-memory", "SKILL.md"));
+  expect(existsSync(dest)).toBe(true);
+  expect(readFileSync(dest, "utf-8")).toContain("name: honcho-memory");
+  expect(hasSkill(dir)).toBe(true);
+});
+
+test("installSkill is idempotent", () => {
+  const dir = tmpSkills();
+  installSkill(dir);
+  const dest = installSkill(dir);
+  expect(existsSync(dest)).toBe(true);
+});
+
+test("removeSkill deletes it and reports state", () => {
+  const dir = tmpSkills();
+  installSkill(dir);
+  expect(removeSkill(dir)).toBe(true);
+  expect(hasSkill(dir)).toBe(false);
+  expect(removeSkill(dir)).toBe(false);
+});

--- a/test/hooks/observe.test.ts
+++ b/test/hooks/observe.test.ts
@@ -20,7 +20,12 @@ test("extracts edited files from an apply_patch", () => {
 });
 
 test("falls back to a generic note for unknown tools", () => {
-  expect(summarizeTool("mcp__honcho__search", {})).toBe("used mcp__honcho__search");
+  expect(summarizeTool("mcp__linear__list_issues", {})).toBe("used mcp__linear__list_issues");
+});
+
+test("never records Honcho's own MCP calls (circular)", () => {
+  expect(summarizeTool("mcp__honcho__chat", {})).toBe("");
+  expect(summarizeTool("mcp__honcho__get_peer_card", {})).toBe("");
 });
 
 test("empty tool name yields nothing", () => {

--- a/test/hooks/prompt.test.ts
+++ b/test/hooks/prompt.test.ts
@@ -1,0 +1,40 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { prompt } from "../../src/hooks/prompt.ts";
+
+let dir = "";
+const savedDir = process.env.HONCHO_CONFIG_DIR;
+
+function writeConfig(obj: object) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "config.json"), JSON.stringify(obj));
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "codex-honcho-prompt-"));
+  process.env.HONCHO_CONFIG_DIR = dir;
+});
+
+afterEach(() => {
+  if (savedDir === undefined) delete process.env.HONCHO_CONFIG_DIR;
+  else process.env.HONCHO_CONFIG_DIR = savedDir;
+});
+
+test("returns nothing when per-prompt injection is off (default) — no network", async () => {
+  writeConfig({ apiKey: "k", peerName: "eri" });
+  const out = await prompt({ prompt: "how is auth done?", cwd: "/tmp/x", session_id: "s1" });
+  expect(out).toBe("");
+});
+
+test("returns nothing for a trivial prompt even when injection is on", async () => {
+  writeConfig({ apiKey: "k", peerName: "eri", hosts: { codex: { injectPerPrompt: true } } });
+  expect(await prompt({ prompt: "ok", cwd: "/tmp/x", session_id: "s1" })).toBe("");
+});
+
+test("returns nothing when enabled but there is no cached context (no network)", async () => {
+  writeConfig({ apiKey: "k", peerName: "eri", hosts: { codex: { injectPerPrompt: true } } });
+  const out = await prompt({ prompt: "tell me about the project", cwd: "/tmp/x", session_id: "no-cache" });
+  expect(out).toBe("");
+});

--- a/test/hooks/writeback.test.ts
+++ b/test/hooks/writeback.test.ts
@@ -1,0 +1,56 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { capture } from "../../src/hooks/writeback.ts";
+import { readQueue, pendingCount } from "../../src/queue.ts";
+
+const savedDir = process.env.HONCHO_CONFIG_DIR;
+let rollout = "";
+
+function writeRollout(turns: Array<{ role: string; text: string }>) {
+  const lines = turns.map((t) => ({
+    type: "response_item",
+    payload: { type: "message", role: t.role, content: [{ type: t.role === "user" ? "input_text" : "output_text", text: t.text }] },
+  }));
+  writeFileSync(rollout, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+}
+
+beforeEach(() => {
+  const dir = mkdtempSync(join(tmpdir(), "codex-honcho-wb-"));
+  process.env.HONCHO_CONFIG_DIR = dir;
+  rollout = join(dir, "rollout.jsonl");
+});
+
+afterEach(() => {
+  if (savedDir === undefined) delete process.env.HONCHO_CONFIG_DIR;
+  else process.env.HONCHO_CONFIG_DIR = savedDir;
+});
+
+test("capture enqueues fresh turns and is incremental across calls", () => {
+  writeRollout([{ role: "user", text: "first" }, { role: "assistant", text: "reply" }]);
+  expect(capture("s1", rollout)).toBe(2);
+  expect(readQueue("s1").map((e) => e.text)).toEqual(["first", "reply"]);
+
+  // Second call with no new turns enqueues nothing.
+  expect(capture("s1", rollout)).toBe(0);
+
+  // A new turn appears → only the delta is captured.
+  writeRollout([
+    { role: "user", text: "first" },
+    { role: "assistant", text: "reply" },
+    { role: "user", text: "second" },
+  ]);
+  expect(capture("s1", rollout)).toBe(1);
+  expect(pendingCount("s1")).toBe(3);
+  expect(readQueue("s1").at(-1)?.text).toBe("second");
+});
+
+test("capture skips Codex-injected system turns", () => {
+  writeRollout([
+    { role: "user", text: "<environment_context><cwd>/x</cwd></environment_context>" },
+    { role: "user", text: "real prompt" },
+  ]);
+  expect(capture("s2", rollout)).toBe(1);
+  expect(readQueue("s2").map((e) => e.text)).toEqual(["real prompt"]);
+});

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -1,0 +1,49 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { enqueue, readQueue, pending, pendingCount, sentCount, setSentCount } from "../src/queue.ts";
+
+const savedDir = process.env.HONCHO_CONFIG_DIR;
+
+beforeEach(() => {
+  process.env.HONCHO_CONFIG_DIR = mkdtempSync(join(tmpdir(), "codex-honcho-q-"));
+});
+
+afterEach(() => {
+  if (savedDir === undefined) delete process.env.HONCHO_CONFIG_DIR;
+  else process.env.HONCHO_CONFIG_DIR = savedDir;
+});
+
+test("enqueue appends and readQueue returns in order", () => {
+  enqueue("k", [{ role: "user", text: "a" }, { role: "assistant", text: "b" }]);
+  enqueue("k", [{ role: "tool", text: "ran: bun test" }]);
+  expect(readQueue("k").map((e) => e.text)).toEqual(["a", "b", "ran: bun test"]);
+});
+
+test("pending reflects unsent entries past the sent marker", () => {
+  enqueue("k", [{ role: "user", text: "a" }, { role: "assistant", text: "b" }, { role: "user", text: "c" }]);
+  expect(pendingCount("k")).toBe(3);
+  setSentCount("k", 2);
+  expect(pending("k").map((e) => e.text)).toEqual(["c"]);
+  expect(pendingCount("k")).toBe(1);
+});
+
+test("append-only: new entries after a partial send are still pending", () => {
+  enqueue("k", [{ role: "user", text: "a" }]);
+  setSentCount("k", 1);
+  enqueue("k", [{ role: "assistant", text: "b" }]);
+  expect(pendingCount("k")).toBe(1);
+  expect(pending("k")[0].text).toBe("b");
+});
+
+test("empty enqueue is a no-op", () => {
+  enqueue("k", []);
+  expect(readQueue("k")).toEqual([]);
+  expect(sentCount("k")).toBe(0);
+});
+
+test("missing queue reads as empty", () => {
+  expect(readQueue("nope")).toEqual([]);
+  expect(pendingCount("nope")).toBe(0);
+});

--- a/test/transcript/codex.test.ts
+++ b/test/transcript/codex.test.ts
@@ -57,6 +57,18 @@ test("missing file yields no turns and no cwd", () => {
   expect(readRolloutCwd("/no/such/rollout.jsonl")).toBeUndefined();
 });
 
+test("drops Codex-injected system turns (environment_context, etc.)", () => {
+  const path = writeRollout([
+    { type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "<environment_context>\n  <cwd>/x</cwd>\n</environment_context>" }] } },
+    { type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "<turn_aborted>interrupted</turn_aborted>" }] } },
+    { type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "<skills_instructions>use skills</skills_instructions>" }] } },
+    { type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "actual question from me" }] } },
+  ]);
+  const turns = readRollout(path);
+  expect(turns).toHaveLength(1);
+  expect(turns[0].text).toBe("actual question from me");
+});
+
 test("skips malformed lines without throwing", () => {
   const path = writeRollout([
     { type: "session_meta", payload: { cwd: "/tmp/x" } },


### PR DESCRIPTION
Harness-level Honcho memory for OpenAI Codex — sibling to claude-honcho, same backend, different harness.

## What's here
- **Rollout reader** (`src/transcript/codex.ts`) — parses Codex `~/.codex/sessions/*.jsonl` (`input_text`/`output_text` event format).
- **Connectors** — idempotent, foreign-config-safe install/remove of: Codex hooks (`hooks.json`), `[features].hooks = true`, the hosted Honcho MCP (`mcp.honcho.dev`) in `config.toml`, and the `honcho-memory` skill. `CODEX_HOME` override for custom/test targets.
- **Hooks** — `recall` (SessionStart: context + dialectic + tool nudge), `prompt` (UserPromptSubmit: prompt-scoped context), `observe` (PostToolUse), `writeback` (Stop + PreCompact: per-turn rollout deltas via a cursor).
- **Bin** — `install` / `remove` / `status` / `<verb>` dispatch; every hook path best-effort (always exit 0).

## Design notes
- Codex `Stop` is turn-scoped (no SessionEnd), so writeback ships only the new tail via a session cursor — no daemon, no SQLite, straight to the Honcho SDK.
- Context injects via plain stdout (works identically on Codex and Claude).
- Uses Honcho's hosted MCP rather than shipping a server.

## Tests
47 unit tests (transcript, cursor delta, config resolution, tool summarizer, all connectors), typecheck clean. Full install→remove verified against a sandbox `CODEX_HOME`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Honcho-backed active memory recall with optional background refinement, durable local queue/flush worker, filesystem cache, per-prompt injection toggle, installer and enhanced CLI install/remove/status, and background hook execution.

* **Documentation**
  * README overhauled with memory flow, diagrams, install/uninstall steps, and expanded configuration examples.

* **Tests**
  * Added/updated tests covering MCP config injection, skill install/remove, queue/flush behavior, prompt injection, hooks, and transcript filtering.

* **Chores**
  * Updated package metadata and published files list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->