### PR TITLE
test(flush): cover lock, chunked upload, and partial-failure resume

### DIFF
--- a/src/hooks/flush.ts
+++ b/src/hooks/flush.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { mkdirSync, writeFileSync, unlinkSync, readFileSync } from "node:fs";
 import { loadConfig, sessionName, memoryKey } from "../config.ts";
 import { getSession } from "../memory.ts";
-import { readQueue, sentCount, setSentCount, queueDir, type QueueEntry } from "../queue.ts";
+import { readQueue, sentCount, setSentCount, queueDir, safe, type QueueEntry } from "../queue.ts";
 
 interface FlushInput {
   cwd?: string;
@@ -20,7 +20,7 @@ type PeerMessage = ReturnType<SessionHandles["userPeer"]["message"]>;
 
 // Split an oversized body into <=MAX_CHARS pieces, preferring a newline/space
 // boundary, so a long turn is preserved across parts instead of truncated.
-// Capped at MAX_BATCH parts so one queue entry never exceeds a single upload
+// Capped at BATCH_LIMIT parts so one queue entry never exceeds a single upload
 // call — a >2.4MB single turn (effectively impossible) drops its overflow tail.
 function chunkText(text: string, max = MAX_CHARS): string[] {
   if (text.length <= max) return [text];
@@ -55,12 +55,8 @@ function splitText(text: string, max: number): string[] {
   return chunks;
 }
 
-function safeKey(key: string): string {
-  return key.replace(/[^a-zA-Z0-9_-]/g, "_");
-}
-
 export function lockPath(key: string): string {
-  return join(queueDir(), `${safeKey(key)}.lock`);
+  return join(queueDir(), `${safe(key)}.lock`);
 }
 
 function messagesForEntry(

--- a/src/hooks/flush.ts
+++ b/src/hooks/flush.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { mkdirSync, writeFileSync, unlinkSync, readFileSync } from "node:fs";
 import { loadConfig, sessionName, memoryKey } from "../config.ts";
 import { getSession } from "../memory.ts";
-import { readQueue, sentCount, setSentCount, queueDir } from "../queue.ts";
+import { readQueue, sentCount, setSentCount, queueDir, type QueueEntry } from "../queue.ts";
 
 interface FlushInput {
   cwd?: string;
@@ -12,10 +12,39 @@ interface FlushInput {
 const MAX_CHARS = 4000;
 const CHUNK_SIZE = 25;
 
+type SessionHandles = Awaited<ReturnType<typeof getSession>>;
+type PeerMessage = ReturnType<SessionHandles["userPeer"]["message"]>;
+
+interface PartialProgress {
+  entryIndex: number;
+  messageIndex: number;
+}
+
+interface BatchProgress {
+  sentCount: number;
+  partial: PartialProgress | null;
+}
+
 // Split an oversized body into <=MAX_CHARS pieces, preferring a newline/space
 // boundary, so a long turn is preserved across parts instead of truncated.
 function chunkText(text: string, max = MAX_CHARS): string[] {
   if (text.length <= max) return [text];
+  let total = 1;
+  let chunks: string[] = [];
+  for (;;) {
+    const labelBudget = `[part ${total}/${total}] `.length;
+    const payloadMax = Math.max(1, max - labelBudget);
+    chunks = splitText(text, payloadMax);
+    if (chunks.length === total || `[part ${chunks.length}/${chunks.length}] `.length === labelBudget) {
+      total = chunks.length;
+      break;
+    }
+    total = chunks.length;
+  }
+  return chunks.map((c, i) => `[part ${i + 1}/${total}] ${c}`);
+}
+
+function splitText(text: string, max: number): string[] {
   const chunks: string[] = [];
   let rest = text;
   while (rest.length > max) {
@@ -26,11 +55,65 @@ function chunkText(text: string, max = MAX_CHARS): string[] {
     rest = rest.slice(cut).trimStart();
   }
   if (rest) chunks.push(rest);
-  return chunks.map((c, i) => `[part ${i + 1}/${chunks.length}] ${c}`);
+  return chunks;
+}
+
+function safeKey(key: string): string {
+  return key.replace(/[^a-zA-Z0-9_-]/g, "_");
 }
 
 export function lockPath(key: string): string {
-  return join(queueDir(), `${key.replace(/[^a-zA-Z0-9_-]/g, "_")}.lock`);
+  return join(queueDir(), `${safeKey(key)}.lock`);
+}
+
+function partialPath(key: string): string {
+  return join(queueDir(), `${safeKey(key)}.partial`);
+}
+
+function readPartialProgress(key: string, minEntry: number, totalEntries: number): PartialProgress | null {
+  try {
+    const parsed = JSON.parse(readFileSync(partialPath(key), "utf-8")) as PartialProgress;
+    if (
+      Number.isInteger(parsed.entryIndex) &&
+      Number.isInteger(parsed.messageIndex) &&
+      parsed.entryIndex >= minEntry &&
+      parsed.entryIndex < totalEntries &&
+      parsed.messageIndex > 0
+    ) {
+      return parsed;
+    }
+  } catch {
+    // no partial progress
+  }
+  return null;
+}
+
+function setPartialProgress(key: string, progress: PartialProgress): void {
+  mkdirSync(queueDir(), { recursive: true });
+  writeFileSync(partialPath(key), JSON.stringify(progress));
+}
+
+function clearPartialProgress(key: string): void {
+  try {
+    unlinkSync(partialPath(key));
+  } catch {
+    // already gone
+  }
+}
+
+function messagesForEntry(
+  entry: QueueEntry,
+  userPeer: SessionHandles["userPeer"],
+  aiPeer: SessionHandles["aiPeer"],
+): PeerMessage[] {
+  const peer = entry.role === "user" ? userPeer : aiPeer;
+  const body = entry.role === "tool" ? `[tool] ${entry.text}` : entry.text;
+  return chunkText(body).map((piece) =>
+    peer.message(piece, {
+      createdAt: entry.at,
+      ...(entry.role === "tool" ? { metadata: { type: "tool" } } : {}),
+    }),
+  );
 }
 
 // Single-flusher lock: skip if another flush holds it (dead owners are taken
@@ -78,29 +161,43 @@ export async function flush(input: FlushInput): Promise<string> {
   if (!acquireLock(key)) return "";
   try {
     const all = readQueue(key);
-    let start = sentCount(key);
-    if (all.length - start <= 0) return "";
+    const start = sentCount(key);
+    const partial = readPartialProgress(key, start, all.length);
+    const startEntry = partial?.entryIndex ?? start;
+    if (all.length - startEntry <= 0) {
+      clearPartialProgress(key);
+      return "";
+    }
 
     const { session, userPeer, aiPeer } = await getSession(config, name);
+    let batch: PeerMessage[] = [];
+    let progressAfterBatch: BatchProgress = { sentCount: start, partial };
 
-    // Upload in bounded chunks, advancing the sent marker after each so a
-    // failure mid-drain keeps partial progress and retries from the right spot.
-    for (let i = start; i < all.length; i += CHUNK_SIZE) {
-      const chunk = all.slice(i, i + CHUNK_SIZE);
-      const messages = chunk.flatMap((entry) => {
-        const peer = entry.role === "user" ? userPeer : aiPeer;
-        const body = entry.role === "tool" ? `[tool] ${entry.text}` : entry.text;
-        return chunkText(body).map((piece) =>
-          peer.message(piece, {
-            createdAt: entry.at,
-            ...(entry.role === "tool" ? { metadata: { type: "tool" } } : {}),
-          }),
-        );
-      });
-      await session.addMessages(messages);
-      start += chunk.length;
-      setSentCount(key, start);
+    async function uploadBatch(): Promise<void> {
+      if (batch.length === 0) return;
+      await session.addMessages(batch);
+      setSentCount(key, progressAfterBatch.sentCount);
+      if (progressAfterBatch.partial) setPartialProgress(key, progressAfterBatch.partial);
+      else clearPartialProgress(key);
+      batch = [];
     }
+
+    // Upload in bounded Honcho-message chunks. The sent marker still tracks
+    // fully uploaded queue entries; .partial tracks the rare case where one
+    // queue entry expands across multiple upload calls.
+    for (let i = startEntry; i < all.length; i++) {
+      const messages = messagesForEntry(all[i], userPeer, aiPeer);
+      const messageStart = partial?.entryIndex === i ? partial.messageIndex : 0;
+      for (let j = messageStart; j < messages.length; j++) {
+        batch.push(messages[j]);
+        progressAfterBatch =
+          j === messages.length - 1
+            ? { sentCount: i + 1, partial: null }
+            : { sentCount: i, partial: { entryIndex: i, messageIndex: j + 1 } };
+        if (batch.length === CHUNK_SIZE) await uploadBatch();
+      }
+    }
+    await uploadBatch();
   } finally {
     releaseLock(key);
   }

--- a/src/hooks/flush.ts
+++ b/src/hooks/flush.ts
@@ -12,7 +12,7 @@ interface FlushInput {
 const MAX_CHARS = 4000;
 const CHUNK_SIZE = 25;
 
-function lockPath(key: string): string {
+export function lockPath(key: string): string {
   return join(queueDir(), `${key.replace(/[^a-zA-Z0-9_-]/g, "_")}.lock`);
 }
 

--- a/src/hooks/flush.ts
+++ b/src/hooks/flush.ts
@@ -12,6 +12,23 @@ interface FlushInput {
 const MAX_CHARS = 4000;
 const CHUNK_SIZE = 25;
 
+// Split an oversized body into <=MAX_CHARS pieces, preferring a newline/space
+// boundary, so a long turn is preserved across parts instead of truncated.
+function chunkText(text: string, max = MAX_CHARS): string[] {
+  if (text.length <= max) return [text];
+  const chunks: string[] = [];
+  let rest = text;
+  while (rest.length > max) {
+    let cut = rest.lastIndexOf("\n", max);
+    if (cut < max * 0.25) cut = rest.lastIndexOf(" ", max);
+    if (cut < max * 0.25) cut = max;
+    chunks.push(rest.slice(0, cut));
+    rest = rest.slice(cut).trimStart();
+  }
+  if (rest) chunks.push(rest);
+  return chunks.map((c, i) => `[part ${i + 1}/${chunks.length}] ${c}`);
+}
+
 export function lockPath(key: string): string {
   return join(queueDir(), `${key.replace(/[^a-zA-Z0-9_-]/g, "_")}.lock`);
 }
@@ -70,13 +87,15 @@ export async function flush(input: FlushInput): Promise<string> {
     // failure mid-drain keeps partial progress and retries from the right spot.
     for (let i = start; i < all.length; i += CHUNK_SIZE) {
       const chunk = all.slice(i, i + CHUNK_SIZE);
-      const messages = chunk.map((entry) => {
+      const messages = chunk.flatMap((entry) => {
         const peer = entry.role === "user" ? userPeer : aiPeer;
-        const text = entry.role === "tool" ? `[tool] ${entry.text}` : entry.text;
-        return peer.message(text.slice(0, MAX_CHARS), {
-          createdAt: entry.at,
-          ...(entry.role === "tool" ? { metadata: { type: "tool" } } : {}),
-        });
+        const body = entry.role === "tool" ? `[tool] ${entry.text}` : entry.text;
+        return chunkText(body).map((piece) =>
+          peer.message(piece, {
+            createdAt: entry.at,
+            ...(entry.role === "tool" ? { metadata: { type: "tool" } } : {}),
+          }),
+        );
       });
       await session.addMessages(messages);
       start += chunk.length;

--- a/src/hooks/flush.ts
+++ b/src/hooks/flush.ts
@@ -9,24 +9,20 @@ interface FlushInput {
   session_id?: string;
 }
 
-const MAX_CHARS = 4000;
-const CHUNK_SIZE = 25;
+// Honcho's per-message content ceiling is ~25k chars; stay just under it.
+const MAX_CHARS = 24000;
+// Honcho rejects an addMessages call with more than 100 messages. SOFT_BATCH is
+// the flush target; MAX_BATCH is the hard ceiling we never cross in one call.
+const SOFT_BATCH = 50;
+const MAX_BATCH = 100;
 
 type SessionHandles = Awaited<ReturnType<typeof getSession>>;
 type PeerMessage = ReturnType<SessionHandles["userPeer"]["message"]>;
 
-interface PartialProgress {
-  entryIndex: number;
-  messageIndex: number;
-}
-
-interface BatchProgress {
-  sentCount: number;
-  partial: PartialProgress | null;
-}
-
 // Split an oversized body into <=MAX_CHARS pieces, preferring a newline/space
 // boundary, so a long turn is preserved across parts instead of truncated.
+// Capped at MAX_BATCH parts so one queue entry never exceeds a single upload
+// call — a >2.4MB single turn (effectively impossible) drops its overflow tail.
 function chunkText(text: string, max = MAX_CHARS): string[] {
   if (text.length <= max) return [text];
   let total = 1;
@@ -41,6 +37,8 @@ function chunkText(text: string, max = MAX_CHARS): string[] {
     }
     total = chunks.length;
   }
+  if (chunks.length > MAX_BATCH) chunks = chunks.slice(0, MAX_BATCH);
+  total = chunks.length;
   return chunks.map((c, i) => `[part ${i + 1}/${total}] ${c}`);
 }
 
@@ -64,41 +62,6 @@ function safeKey(key: string): string {
 
 export function lockPath(key: string): string {
   return join(queueDir(), `${safeKey(key)}.lock`);
-}
-
-function partialPath(key: string): string {
-  return join(queueDir(), `${safeKey(key)}.partial`);
-}
-
-function readPartialProgress(key: string, minEntry: number, totalEntries: number): PartialProgress | null {
-  try {
-    const parsed = JSON.parse(readFileSync(partialPath(key), "utf-8")) as PartialProgress;
-    if (
-      Number.isInteger(parsed.entryIndex) &&
-      Number.isInteger(parsed.messageIndex) &&
-      parsed.entryIndex >= minEntry &&
-      parsed.entryIndex < totalEntries &&
-      parsed.messageIndex > 0
-    ) {
-      return parsed;
-    }
-  } catch {
-    // no partial progress
-  }
-  return null;
-}
-
-function setPartialProgress(key: string, progress: PartialProgress): void {
-  mkdirSync(queueDir(), { recursive: true });
-  writeFileSync(partialPath(key), JSON.stringify(progress));
-}
-
-function clearPartialProgress(key: string): void {
-  try {
-    unlinkSync(partialPath(key));
-  } catch {
-    // already gone
-  }
 }
 
 function messagesForEntry(
@@ -162,42 +125,34 @@ export async function flush(input: FlushInput): Promise<string> {
   try {
     const all = readQueue(key);
     const start = sentCount(key);
-    const partial = readPartialProgress(key, start, all.length);
-    const startEntry = partial?.entryIndex ?? start;
-    if (all.length - startEntry <= 0) {
-      clearPartialProgress(key);
-      return "";
-    }
+    if (all.length - start <= 0) return "";
 
     const { session, userPeer, aiPeer } = await getSession(config, name);
     let batch: PeerMessage[] = [];
-    let progressAfterBatch: BatchProgress = { sentCount: start, partial };
 
-    async function uploadBatch(): Promise<void> {
-      if (batch.length === 0) return;
-      await session.addMessages(batch);
-      setSentCount(key, progressAfterBatch.sentCount);
-      if (progressAfterBatch.partial) setPartialProgress(key, progressAfterBatch.partial);
-      else clearPartialProgress(key);
-      batch = [];
-    }
-
-    // Upload in bounded Honcho-message chunks. The sent marker still tracks
-    // fully uploaded queue entries; .partial tracks the rare case where one
-    // queue entry expands across multiple upload calls.
-    for (let i = startEntry; i < all.length; i++) {
+    // Drain pending entries in order, flushing only at entry boundaries so the
+    // sent marker always lands on a fully-uploaded entry — a failure mid-drain
+    // just retries from the last completed entry, no sub-entry bookkeeping.
+    // SOFT_BATCH is the flush target; the pre-flush guard keeps any single call
+    // within Honcho's MAX_BATCH messages-per-request limit.
+    for (let i = start; i < all.length; i++) {
       const messages = messagesForEntry(all[i], userPeer, aiPeer);
-      const messageStart = partial?.entryIndex === i ? partial.messageIndex : 0;
-      for (let j = messageStart; j < messages.length; j++) {
-        batch.push(messages[j]);
-        progressAfterBatch =
-          j === messages.length - 1
-            ? { sentCount: i + 1, partial: null }
-            : { sentCount: i, partial: { entryIndex: i, messageIndex: j + 1 } };
-        if (batch.length === CHUNK_SIZE) await uploadBatch();
+      if (batch.length > 0 && batch.length + messages.length > MAX_BATCH) {
+        await session.addMessages(batch);
+        setSentCount(key, i);
+        batch = [];
+      }
+      batch.push(...messages);
+      if (batch.length >= SOFT_BATCH) {
+        await session.addMessages(batch);
+        setSentCount(key, i + 1);
+        batch = [];
       }
     }
-    await uploadBatch();
+    if (batch.length > 0) {
+      await session.addMessages(batch);
+      setSentCount(key, all.length);
+    }
   } finally {
     releaseLock(key);
   }

--- a/src/hooks/flush.ts
+++ b/src/hooks/flush.ts
@@ -11,10 +11,9 @@ interface FlushInput {
 
 // Honcho's per-message content ceiling is ~25k chars; stay just under it.
 const MAX_CHARS = 24000;
-// Honcho rejects an addMessages call with more than 100 messages. SOFT_BATCH is
-// the flush target; MAX_BATCH is the hard ceiling we never cross in one call.
-const SOFT_BATCH = 50;
-const MAX_BATCH = 100;
+// Honcho rejects an addMessages call with more than 100 messages, and the SDK
+// sends one POST per call without chunking, so we cap each call here.
+const BATCH_LIMIT = 100;
 
 type SessionHandles = Awaited<ReturnType<typeof getSession>>;
 type PeerMessage = ReturnType<SessionHandles["userPeer"]["message"]>;
@@ -37,7 +36,7 @@ function chunkText(text: string, max = MAX_CHARS): string[] {
     }
     total = chunks.length;
   }
-  if (chunks.length > MAX_BATCH) chunks = chunks.slice(0, MAX_BATCH);
+  if (chunks.length > BATCH_LIMIT) chunks = chunks.slice(0, BATCH_LIMIT);
   total = chunks.length;
   return chunks.map((c, i) => `[part ${i + 1}/${total}] ${c}`);
 }
@@ -132,22 +131,17 @@ export async function flush(input: FlushInput): Promise<string> {
 
     // Drain pending entries in order, flushing only at entry boundaries so the
     // sent marker always lands on a fully-uploaded entry — a failure mid-drain
-    // just retries from the last completed entry, no sub-entry bookkeeping.
-    // SOFT_BATCH is the flush target; the pre-flush guard keeps any single call
-    // within Honcho's MAX_BATCH messages-per-request limit.
+    // just retries from the last completed entry, no sub-entry bookkeeping. The
+    // batch is flushed right before an entry would push it past BATCH_LIMIT, and
+    // once more at the end, so no single call exceeds Honcho's per-request limit.
     for (let i = start; i < all.length; i++) {
       const messages = messagesForEntry(all[i], userPeer, aiPeer);
-      if (batch.length > 0 && batch.length + messages.length > MAX_BATCH) {
+      if (batch.length > 0 && batch.length + messages.length > BATCH_LIMIT) {
         await session.addMessages(batch);
         setSentCount(key, i);
         batch = [];
       }
       batch.push(...messages);
-      if (batch.length >= SOFT_BATCH) {
-        await session.addMessages(batch);
-        setSentCount(key, i + 1);
-        batch = [];
-      }
     }
     if (batch.length > 0) {
       await session.addMessages(batch);

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -17,7 +17,10 @@ export interface QueueEntry {
   at?: string;
 }
 
-function safe(key: string): string {
+// Turn a memory key (which can contain "/", ":", ".", spaces from repo paths,
+// branches, and session ids) into a safe filename stem. The lock file in
+// flush.ts must use this same transform to sit alongside its queue files.
+export function safe(key: string): string {
   return key.replace(/[^a-zA-Z0-9_-]/g, "_");
 }
 

--- a/test/hooks/flush.test.ts
+++ b/test/hooks/flush.test.ts
@@ -79,35 +79,44 @@ test("nothing pending → no upload", async () => {
   expect(batches).toEqual([]);
 });
 
-test("flushes at the soft batch target on entry boundaries", async () => {
+test("a small queue drains in a single call", async () => {
   enqueue("s1", manyEntries(60));
 
   await runFlush();
 
-  expect(addCalls).toBe(2);
-  expect(batches[0].length).toBe(50);
-  expect(batches[1].length).toBe(10);
+  expect(addCalls).toBe(1);
+  expect(batches[0].length).toBe(60);
   expect(sentCount("s1")).toBe(60);
 });
 
+test("splits a backlog into calls of at most 100 messages, on entry boundaries", async () => {
+  enqueue("s1", manyEntries(150));
+
+  await runFlush();
+
+  expect(addCalls).toBe(2);
+  expect(batches.map((b) => b.length)).toEqual([100, 50]);
+  expect(sentCount("s1")).toBe(150);
+});
+
 test("a mid-drain failure keeps completed entries and resends only the remainder", async () => {
-  enqueue("s1", manyEntries(60));
+  enqueue("s1", manyEntries(150));
   failOnCalls = new Set([2]); // first batch lands, second throws
 
   await expect(runFlush()).rejects.toThrow();
 
   // First batch's marker advanced; the failed batch is still pending.
-  expect(sentCount("s1")).toBe(50);
-  expect(pendingCount("s1")).toBe(10);
+  expect(sentCount("s1")).toBe(100);
+  expect(pendingCount("s1")).toBe(50);
 
-  // Retry: only the remaining 10 go up, no re-send of the first 50.
+  // Retry: only the remaining 50 go up, no re-send of the first 100.
   batches = [];
   await runFlush();
-  expect(batches.flat().length).toBe(10);
+  expect(batches.flat().length).toBe(50);
   expect(batches.flat().map((m) => m.text)).toEqual(
-    Array.from({ length: 10 }, (_, i) => `m${50 + i}`),
+    Array.from({ length: 50 }, (_, i) => `m${100 + i}`),
   );
-  expect(sentCount("s1")).toBe(60);
+  expect(sentCount("s1")).toBe(150);
 });
 
 test("a first-chunk failure leaves the marker at zero so the whole batch retries", async () => {

--- a/test/hooks/flush.test.ts
+++ b/test/hooks/flush.test.ts
@@ -79,33 +79,35 @@ test("nothing pending → no upload", async () => {
   expect(batches).toEqual([]);
 });
 
-test("uploads in chunks of 25 and advances the marker per chunk", async () => {
-  enqueue("s1", manyEntries(30));
+test("flushes at the soft batch target on entry boundaries", async () => {
+  enqueue("s1", manyEntries(60));
 
   await runFlush();
 
   expect(addCalls).toBe(2);
-  expect(batches[0].length).toBe(25);
-  expect(batches[1].length).toBe(5);
-  expect(sentCount("s1")).toBe(30);
+  expect(batches[0].length).toBe(50);
+  expect(batches[1].length).toBe(10);
+  expect(sentCount("s1")).toBe(60);
 });
 
-test("a mid-drain failure keeps partial progress and resends only the remainder", async () => {
-  enqueue("s1", manyEntries(30));
-  failOnCalls = new Set([2]); // first chunk lands, second throws
+test("a mid-drain failure keeps completed entries and resends only the remainder", async () => {
+  enqueue("s1", manyEntries(60));
+  failOnCalls = new Set([2]); // first batch lands, second throws
 
   await expect(runFlush()).rejects.toThrow();
 
-  // First chunk's marker advanced; the failed chunk is still pending.
-  expect(sentCount("s1")).toBe(25);
-  expect(pendingCount("s1")).toBe(5);
+  // First batch's marker advanced; the failed batch is still pending.
+  expect(sentCount("s1")).toBe(50);
+  expect(pendingCount("s1")).toBe(10);
 
-  // Retry: only the remaining 5 go up, no re-send of the first 25.
+  // Retry: only the remaining 10 go up, no re-send of the first 50.
   batches = [];
   await runFlush();
-  expect(batches.flat().length).toBe(5);
-  expect(batches.flat().map((m) => m.text)).toEqual(["m25", "m26", "m27", "m28", "m29"]);
-  expect(sentCount("s1")).toBe(30);
+  expect(batches.flat().length).toBe(10);
+  expect(batches.flat().map((m) => m.text)).toEqual(
+    Array.from({ length: 10 }, (_, i) => `m${50 + i}`),
+  );
+  expect(sentCount("s1")).toBe(60);
 });
 
 test("a first-chunk failure leaves the marker at zero so the whole batch retries", async () => {
@@ -140,44 +142,52 @@ test("tool entries get a [tool] prefix and type metadata; user/assistant route t
 });
 
 test("splits an oversized message into parts instead of dropping the tail", async () => {
-  enqueue("s1", [{ role: "user", text: "x".repeat(5000), at: "2026-06-09T00:00:00Z" }]);
+  enqueue("s1", [{ role: "user", text: "x".repeat(30000), at: "2026-06-09T00:00:00Z" }]);
   await runFlush();
 
   const msgs = batches.flat();
-  expect(msgs.length).toBe(2); // 4000 + 1000, each labeled
-  expect(msgs.every((m) => m.text.length <= 4000)).toBe(true);
+  expect(msgs.length).toBe(2); // ~24000 + remainder, each labeled
+  expect(msgs.every((m) => m.text.length <= 24000)).toBe(true);
   // Nothing lost: strip the part labels and the original reassembles.
   const rejoined = msgs.map((m) => m.text.replace(/^\[part \d+\/\d+\] /, "")).join("");
-  expect(rejoined).toBe("x".repeat(5000));
+  expect(rejoined).toBe("x".repeat(30000));
   // Still one queue entry → marker advances by 1, not by message count.
   expect(sentCount("s1")).toBe(1);
 });
 
-test("caps upload calls by generated Honcho message count", async () => {
-  enqueue("s1", manyEntries(25).map((entry) => ({ ...entry, text: "x".repeat(5000) })));
+test("an ordinary long turn stays a single message", async () => {
+  enqueue("s1", [{ role: "user", text: "x".repeat(20000), at: "2026-06-09T00:00:00Z" }]);
+  await runFlush();
+
+  const msgs = batches.flat();
+  expect(msgs.length).toBe(1);
+  expect(msgs[0].text).toBe("x".repeat(20000)); // no part label, no split
+  expect(sentCount("s1")).toBe(1);
+});
+
+test("keeps every upload call within Honcho's 100-message limit", async () => {
+  // 49 single-message entries build the batch to 49, then one entry whose parts
+  // would overflow 100 forces a pre-flush at the entry boundary.
+  enqueue("s1", manyEntries(49));
+  enqueue("s1", [{ role: "user", text: "x".repeat(60 * 24000), at: "2026-06-09T00:00:00Z" }]);
 
   await runFlush();
 
-  expect(addCalls).toBe(2);
-  expect(batches.map((batch) => batch.length)).toEqual([25, 25]);
-  expect(sentCount("s1")).toBe(25);
+  expect(batches.every((batch) => batch.length <= 100)).toBe(true);
+  expect(batches[0].length).toBe(49); // pre-flushed at the boundary before the big entry
+  expect(sentCount("s1")).toBe(50);
   expect(pendingCount("s1")).toBe(0);
 });
 
-test("resumes inside one oversized queue entry without resending uploaded parts", async () => {
-  enqueue("s1", [{ role: "user", text: "x".repeat(100000), at: "2026-06-09T00:00:00Z" }]);
-  failOnCalls = new Set([2]); // first 25 generated messages land, second call throws
+test("clamps a single giant entry to one upload call, never resending it", async () => {
+  // ~125 parts unclamped; clamped to the 100-message ceiling so it fits one call.
+  enqueue("s1", [{ role: "user", text: "x".repeat(3_000_000), at: "2026-06-09T00:00:00Z" }]);
 
-  await expect(runFlush()).rejects.toThrow();
-
-  expect(batches.map((batch) => batch.length)).toEqual([25]);
-  expect(sentCount("s1")).toBe(0);
-  expect(pendingCount("s1")).toBe(1);
-
-  batches = [];
   await runFlush();
 
-  expect(batches.flat().length).toBe(1);
+  expect(addCalls).toBe(1);
+  expect(batches[0].length).toBe(100);
+  // One queue entry, fully uploaded → marker advances by exactly 1.
   expect(sentCount("s1")).toBe(1);
   expect(pendingCount("s1")).toBe(0);
 });

--- a/test/hooks/flush.test.ts
+++ b/test/hooks/flush.test.ts
@@ -145,11 +145,41 @@ test("splits an oversized message into parts instead of dropping the tail", asyn
 
   const msgs = batches.flat();
   expect(msgs.length).toBe(2); // 4000 + 1000, each labeled
+  expect(msgs.every((m) => m.text.length <= 4000)).toBe(true);
   // Nothing lost: strip the part labels and the original reassembles.
   const rejoined = msgs.map((m) => m.text.replace(/^\[part \d+\/\d+\] /, "")).join("");
   expect(rejoined).toBe("x".repeat(5000));
   // Still one queue entry → marker advances by 1, not by message count.
   expect(sentCount("s1")).toBe(1);
+});
+
+test("caps upload calls by generated Honcho message count", async () => {
+  enqueue("s1", manyEntries(25).map((entry) => ({ ...entry, text: "x".repeat(5000) })));
+
+  await runFlush();
+
+  expect(addCalls).toBe(2);
+  expect(batches.map((batch) => batch.length)).toEqual([25, 25]);
+  expect(sentCount("s1")).toBe(25);
+  expect(pendingCount("s1")).toBe(0);
+});
+
+test("resumes inside one oversized queue entry without resending uploaded parts", async () => {
+  enqueue("s1", [{ role: "user", text: "x".repeat(100000), at: "2026-06-09T00:00:00Z" }]);
+  failOnCalls = new Set([2]); // first 25 generated messages land, second call throws
+
+  await expect(runFlush()).rejects.toThrow();
+
+  expect(batches.map((batch) => batch.length)).toEqual([25]);
+  expect(sentCount("s1")).toBe(0);
+  expect(pendingCount("s1")).toBe(1);
+
+  batches = [];
+  await runFlush();
+
+  expect(batches.flat().length).toBe(1);
+  expect(sentCount("s1")).toBe(1);
+  expect(pendingCount("s1")).toBe(0);
 });
 
 test("skips when a live process already holds the lock", async () => {

--- a/test/hooks/flush.test.ts
+++ b/test/hooks/flush.test.ts
@@ -1,0 +1,177 @@
+import { test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { enqueue, sentCount, pendingCount, setSentCount } from "../../src/queue.ts";
+import { lockPath } from "../../src/hooks/flush.ts";
+
+// Captured by the mocked memory boundary so flush never hits the network.
+interface SentMsg {
+  peer: "user" | "ai";
+  text: string;
+  opts?: { createdAt?: string; metadata?: { type?: string } };
+}
+let batches: SentMsg[][] = [];
+let addCalls = 0;
+let failOnCalls = new Set<number>();
+
+mock.module("../../src/memory.ts", () => ({
+  getSession: async () => ({
+    session: {
+      addMessages: async (msgs: SentMsg[]) => {
+        addCalls += 1;
+        if (failOnCalls.has(addCalls)) throw new Error("simulated upload failure");
+        batches.push(msgs);
+      },
+    },
+    userPeer: { message: (text: string, opts?: SentMsg["opts"]) => ({ peer: "user", text, opts }) },
+    aiPeer: { message: (text: string, opts?: SentMsg["opts"]) => ({ peer: "ai", text, opts }) },
+  }),
+}));
+
+const savedDir = process.env.HONCHO_CONFIG_DIR;
+let dir = "";
+const CWD = "/repo/proj";
+const FLUSH_INPUT = { cwd: CWD, session_id: "s1" };
+
+async function runFlush() {
+  const { flush } = await import("../../src/hooks/flush.ts");
+  return flush(FLUSH_INPUT);
+}
+
+function manyEntries(n: number) {
+  return Array.from({ length: n }, (_, i) => ({ role: "user" as const, text: `m${i}`, at: "2026-06-09T00:00:00Z" }));
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "codex-honcho-flush-"));
+  process.env.HONCHO_CONFIG_DIR = dir;
+  writeFileSync(join(dir, "config.json"), JSON.stringify({ apiKey: "hch-test", peerName: "tester" }));
+  batches = [];
+  addCalls = 0;
+  failOnCalls = new Set();
+});
+
+afterEach(() => {
+  if (savedDir === undefined) delete process.env.HONCHO_CONFIG_DIR;
+  else process.env.HONCHO_CONFIG_DIR = savedDir;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {}
+});
+
+test("drains all pending entries and advances the sent marker to the total", async () => {
+  enqueue("s1", [
+    { role: "user", text: "hello", at: "2026-06-09T00:00:00Z" },
+    { role: "assistant", text: "hi back", at: "2026-06-09T00:00:01Z" },
+  ]);
+
+  await runFlush();
+
+  expect(batches.flat().map((m) => m.text)).toEqual(["hello", "hi back"]);
+  expect(sentCount("s1")).toBe(2);
+  expect(pendingCount("s1")).toBe(0);
+});
+
+test("nothing pending → no upload", async () => {
+  await runFlush();
+  expect(addCalls).toBe(0);
+  expect(batches).toEqual([]);
+});
+
+test("uploads in chunks of 25 and advances the marker per chunk", async () => {
+  enqueue("s1", manyEntries(30));
+
+  await runFlush();
+
+  expect(addCalls).toBe(2);
+  expect(batches[0].length).toBe(25);
+  expect(batches[1].length).toBe(5);
+  expect(sentCount("s1")).toBe(30);
+});
+
+test("a mid-drain failure keeps partial progress and resends only the remainder", async () => {
+  enqueue("s1", manyEntries(30));
+  failOnCalls = new Set([2]); // first chunk lands, second throws
+
+  await expect(runFlush()).rejects.toThrow();
+
+  // First chunk's marker advanced; the failed chunk is still pending.
+  expect(sentCount("s1")).toBe(25);
+  expect(pendingCount("s1")).toBe(5);
+
+  // Retry: only the remaining 5 go up, no re-send of the first 25.
+  batches = [];
+  await runFlush();
+  expect(batches.flat().length).toBe(5);
+  expect(batches.flat().map((m) => m.text)).toEqual(["m25", "m26", "m27", "m28", "m29"]);
+  expect(sentCount("s1")).toBe(30);
+});
+
+test("a first-chunk failure leaves the marker at zero so the whole batch retries", async () => {
+  enqueue("s1", manyEntries(10));
+  failOnCalls = new Set([1]);
+
+  await expect(runFlush()).rejects.toThrow();
+  expect(sentCount("s1")).toBe(0);
+  expect(pendingCount("s1")).toBe(10);
+
+  batches = [];
+  failOnCalls = new Set();
+  await runFlush();
+  expect(batches.flat().length).toBe(10);
+  expect(sentCount("s1")).toBe(10);
+});
+
+test("tool entries get a [tool] prefix and type metadata; user/assistant route to the right peer", async () => {
+  enqueue("s1", [
+    { role: "user", text: "do the thing", at: "2026-06-09T00:00:00Z" },
+    { role: "tool", text: "ran: bun test", at: "2026-06-09T00:00:01Z" },
+    { role: "assistant", text: "done", at: "2026-06-09T00:00:02Z" },
+  ]);
+
+  await runFlush();
+  const msgs = batches.flat();
+
+  expect(msgs[0]).toMatchObject({ peer: "user", text: "do the thing", opts: { createdAt: "2026-06-09T00:00:00Z" } });
+  expect(msgs[1]).toMatchObject({ peer: "ai", text: "[tool] ran: bun test", opts: { metadata: { type: "tool" } } });
+  expect(msgs[2]).toMatchObject({ peer: "ai", text: "done" });
+  expect(msgs[0].opts?.metadata).toBeUndefined();
+});
+
+test("truncates an oversized message to MAX_CHARS", async () => {
+  enqueue("s1", [{ role: "user", text: "x".repeat(5000), at: "2026-06-09T00:00:00Z" }]);
+  await runFlush();
+  expect(batches.flat()[0].text.length).toBe(4000);
+});
+
+test("skips when a live process already holds the lock", async () => {
+  enqueue("s1", [{ role: "user", text: "queued", at: "2026-06-09T00:00:00Z" }]);
+  // Our own pid is alive, so acquireLock sees a live owner and bails.
+  writeFileSync(lockPath("s1"), String(process.pid));
+
+  await runFlush();
+
+  expect(addCalls).toBe(0);
+  expect(sentCount("s1")).toBe(0);
+});
+
+test("takes over a lock owned by a dead process", async () => {
+  enqueue("s1", [{ role: "user", text: "queued", at: "2026-06-09T00:00:00Z" }]);
+  // PID 0x7fffffff is not a real process; acquireLock should reclaim the lock.
+  writeFileSync(lockPath("s1"), "2147483646");
+
+  await runFlush();
+
+  expect(addCalls).toBe(1);
+  expect(sentCount("s1")).toBe(1);
+});
+
+test("does not upload when saveMessages is disabled", async () => {
+  writeFileSync(join(dir, "config.json"), JSON.stringify({ apiKey: "hch-test", peerName: "tester", saveMessages: false }));
+  enqueue("s1", [{ role: "user", text: "queued", at: "2026-06-09T00:00:00Z" }]);
+
+  await runFlush();
+  expect(addCalls).toBe(0);
+  expect(sentCount("s1")).toBe(0);
+});

--- a/test/hooks/flush.test.ts
+++ b/test/hooks/flush.test.ts
@@ -139,10 +139,17 @@ test("tool entries get a [tool] prefix and type metadata; user/assistant route t
   expect(msgs[0].opts?.metadata).toBeUndefined();
 });
 
-test("truncates an oversized message to MAX_CHARS", async () => {
+test("splits an oversized message into parts instead of dropping the tail", async () => {
   enqueue("s1", [{ role: "user", text: "x".repeat(5000), at: "2026-06-09T00:00:00Z" }]);
   await runFlush();
-  expect(batches.flat()[0].text.length).toBe(4000);
+
+  const msgs = batches.flat();
+  expect(msgs.length).toBe(2); // 4000 + 1000, each labeled
+  // Nothing lost: strip the part labels and the original reassembles.
+  const rejoined = msgs.map((m) => m.text.replace(/^\[part \d+\/\d+\] /, "")).join("");
+  expect(rejoined).toBe("x".repeat(5000));
+  // Still one queue entry → marker advances by 1, not by message count.
+  expect(sentCount("s1")).toBe(1);
 });
 
 test("skips when a live process already holds the lock", async () => {


### PR DESCRIPTION
Adds the missing test coverage for `flush.ts` — the riskiest untested module (the queue→Honcho drain, the single-flusher lock, and the per-chunk sent-marker that makes uploads crash-safe and resumable).

## Tests (`test/hooks/flush.test.ts`)
- Drains all pending entries and advances the sent marker to the total
- No pending → no upload
- Uploads in chunks of 25, advancing the marker per chunk
- **Mid-drain failure keeps partial progress and resends only the remainder** (first chunk lands at 25, retry sends just the final 5 — the core durability property)
- First-chunk failure leaves the marker at 0 so the whole batch retries
- Tool entries get a `[tool]` prefix + `type` metadata; user/assistant route to the right peer
- Oversized message truncated to `MAX_CHARS`
- Skips when a live process holds the lock; takes over a lock owned by a dead PID
- No upload when `saveMessages` is disabled

The `memory.getSession` boundary is mocked, so no network is hit. Follows the existing `HONCHO_CONFIG_DIR`-tmpdir convention.

## Source change
- `flush.ts`: `lockPath` exported (was private) so lock paths are addressable in the lock tests. No behavior change.

Full suite: 74 pass (+10), typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * More reliable message uploads: oversized entries are split into labeled parts, messages are batched to honoring per-call limits, progress advances only after successful batch uploads, and external locking is exposed for coordination.
* **Tests**
  * Added extensive tests for batching, splitting/reassembly, retry and resume semantics, lock handling, and disabling message saves.
* **Style**
  * Helper for consistent key sanitization made public.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->