### PR TITLE
fix(mcp): preserve foreign config inside the honcho fence

### DIFF
--- a/src/connectors/mcp.ts
+++ b/src/connectors/mcp.ts
@@ -57,25 +57,41 @@ function stripBlock(content: string): string {
   // tool-approval prefs) inside our fence. Drop only the marker lines and the
   // tables we wrote ([mcp_servers.honcho] + its subtables); keep everything else
   // so an uninstall/reinstall never deletes config we don't own.
-  const out: string[] = [];
+  //
+  // Preserved lines accumulate into chunks; every removed line (a fence marker
+  // or a honcho-table line) cuts a chunk boundary. We normalize blank lines only
+  // at those seams and leave each preserved chunk byte-for-byte intact — never
+  // touching blank lines a user (or a multiline TOML string) put in unrelated
+  // config.
+  const chunks: string[] = [];
+  let current: string[] = [];
   let inFence = false;
   let dropTable = false;
 
+  const cut = () => {
+    if (current.length) { chunks.push(current.join("\n")); current = []; }
+  };
+
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
-    if (trimmed === BLOCK_START) { inFence = true; dropTable = false; continue; }
-    if (trimmed === BLOCK_END) { inFence = false; dropTable = false; continue; }
-    if (!inFence) { out.push(line); continue; }
-
-    const header = trimmed.match(/^\[+\s*([^\]]+?)\s*\]+$/);
-    if (header) {
-      const name = header[1];
-      dropTable = name === "mcp_servers.honcho" || name.startsWith("mcp_servers.honcho.");
+    if (trimmed === BLOCK_START) { inFence = true; dropTable = false; cut(); continue; }
+    if (trimmed === BLOCK_END) { inFence = false; dropTable = false; cut(); continue; }
+    if (inFence) {
+      const header = trimmed.match(/^\[+\s*([^\]]+?)\s*\]+$/);
+      if (header) {
+        const name = header[1];
+        dropTable = name === "mcp_servers.honcho" || name.startsWith("mcp_servers.honcho.");
+      }
+      if (dropTable) { cut(); continue; }
     }
-    if (!dropTable) out.push(line);
+    current.push(line);
   }
+  cut();
 
-  return out.join("\n").replace(/\n{3,}/g, "\n\n").replace(/\n*$/, "") + "\n";
+  const parts = chunks
+    .map((c) => c.replace(/^\n+/, "").replace(/\n+$/, ""))
+    .filter(Boolean);
+  return parts.length ? `${parts.join("\n\n")}\n` : "";
 }
 
 // Replace any existing block with a fresh one; idempotent.

--- a/src/connectors/mcp.ts
+++ b/src/connectors/mcp.ts
@@ -51,13 +51,31 @@ function buildBlock(id: McpIdentity): string {
 }
 
 function stripBlock(content: string): string {
-  const start = content.indexOf(BLOCK_START);
-  if (start === -1) return content;
-  const end = content.indexOf(BLOCK_END, start);
-  if (end === -1) return content;
-  const before = content.slice(0, start).replace(/\n*$/, "");
-  const after = content.slice(end + BLOCK_END.length).replace(/^\n*/, "");
-  return [before, after].filter(Boolean).join("\n\n") + (after ? "" : "\n");
+  if (!content.includes(BLOCK_START)) return content;
+
+  // Codex rewrites config.toml and parks tables it owns (e.g. [hooks.state] or
+  // tool-approval prefs) inside our fence. Drop only the marker lines and the
+  // tables we wrote ([mcp_servers.honcho] + its subtables); keep everything else
+  // so an uninstall/reinstall never deletes config we don't own.
+  const out: string[] = [];
+  let inFence = false;
+  let dropTable = false;
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === BLOCK_START) { inFence = true; dropTable = false; continue; }
+    if (trimmed === BLOCK_END) { inFence = false; dropTable = false; continue; }
+    if (!inFence) { out.push(line); continue; }
+
+    const header = trimmed.match(/^\[+\s*([^\]]+?)\s*\]+$/);
+    if (header) {
+      const name = header[1];
+      dropTable = name === "mcp_servers.honcho" || name.startsWith("mcp_servers.honcho.");
+    }
+    if (!dropTable) out.push(line);
+  }
+
+  return out.join("\n").replace(/\n{3,}/g, "\n\n").replace(/\n*$/, "") + "\n";
 }
 
 // Replace any existing block with a fresh one; idempotent.

--- a/src/connectors/mcp.ts
+++ b/src/connectors/mcp.ts
@@ -77,7 +77,7 @@ function stripBlock(content: string): string {
     if (trimmed === BLOCK_START) { inFence = true; dropTable = false; cut(); continue; }
     if (trimmed === BLOCK_END) { inFence = false; dropTable = false; cut(); continue; }
     if (inFence) {
-      const header = trimmed.match(/^\[+\s*([^\]]+?)\s*\]+$/);
+      const header = trimmed.match(/^\[+\s*([^\]]+?)\s*\]+\s*(#.*)?$/);
       if (header) {
         const name = header[1];
         dropTable = name === "mcp_servers.honcho" || name.startsWith("mcp_servers.honcho.");


### PR DESCRIPTION
## What

`stripBlock` (used by both uninstall and reinstall via `setMcpServer`) deleted **everything** between our `# >>> codex-honcho (honcho mcp) >>>` … `# <<<` markers.

The problem: Codex rewrites `config.toml` and parks tables it manages — `[hooks.state]` (hook trust hashes) and `[mcp_servers.honcho.tools.*]` approval prefs — *inside* that fence (the fence is at the end of the file, where Codex appends). So uninstalling or upgrading silently wiped that config. If a user has hooks from other tools, their trust hashes live in the same `[hooks.state]` table → they'd get re-prompted to trust their own hooks.

## Fix

`stripBlock` now walks the fenced region line-by-line and removes only:
- the two marker lines, and
- the tables we wrote — `[mcp_servers.honcho]` and its subtables.

Anything else Codex left inside the fence (e.g. `[hooks.state]`) is preserved.

## Impact

- Normal installs: no behavior change.
- Uninstall/reinstall/upgrade: no longer eats config we don't own.
- One function changed; existing mcp tests + typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of Honcho MCP settings to remove only the fenced Honcho MCP region and its related TOML tables, preserving all other configuration reliably. Formatting is cleaner after the update, with preserved sections maintained as-is and proper spacing applied where the removed block was.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->