### PR TITLE
[codex] add optional Codex memory bootstrap workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+honcho-bootstrap/
 *.log
 .DS_Store
 .honcho/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add an optional dry-run-first Codex memory bootstrap workflow under `examples/`.
+- Document how to review, preflight, and explicitly approve legacy memory imports into Honcho.
+
 ## 0.1.0
 
 - Initial release — harness-level Honcho memory for OpenAI Codex.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,26 @@ Use the Honcho MCP tools (`search`, `chat`) to recall more mid-task, and
 `create_conclusion` to save new preferences, decisions, and patterns as you learn them.
 ```
 
+### Step 6: (Optional) Bootstrap existing Codex memory
+
+If you already have a local Codex memory corpus in `~/.codex/memories`, you can
+seed Honcho with a curated, dry-run-first import. This is separate from
+`codex-honcho install` because legacy memory can contain stale facts, old live
+verification claims, or low-signal routing notes that should be reviewed before
+upload.
+
+The recommended workflow is to scan `memory_summary.md` and `MEMORY.md`, stage
+reviewable conclusions, preflight exact duplicates, then upload only after
+explicit approval. A useful first import is usually `high-medium`: durable
+preferences, repo conventions, machine gotchas, and failure/fix patterns. Keep
+low-priority topic routes out of the first import unless you intentionally want
+Honcho to act as a broad memory router.
+
+Honcho conclusion timestamps are creation-time only, so the bootstrap preserves
+chronology by appending an inferred source-memory date to each uploaded
+conclusion. See [`examples/bootstrap-codex-memory/`](./examples/bootstrap-codex-memory/)
+for the full workflow and safety notes.
+
 ## MCP Tools
 
 Once installed, Codex can call these Honcho tools directly:

--- a/examples/bootstrap-codex-memory/README.md
+++ b/examples/bootstrap-codex-memory/README.md
@@ -1,0 +1,98 @@
+# Bootstrap Existing Codex Memory
+
+This optional workflow is for users who already have local Codex memory under
+`~/.codex/memories` and want to seed Honcho with reviewed conclusions.
+
+It is intentionally separate from `codex-honcho install`. Installation captures
+future sessions; bootstrapping legacy memory is a migration step that should be
+reviewed before any upload.
+
+## Safety Contract
+
+- Do not upload raw transcripts or whole memory files.
+- Generate a dry run first.
+- Review the staged conclusions before writing to Honcho.
+- Require an explicit approval flag or equivalent confirmation before upload.
+- Treat old live facts, counts, deadlines, prices, and verification claims as
+  stale unless revalidated.
+- Keep low-priority routing/topic-index rows out of the first import unless the
+  user explicitly wants broad search routing.
+
+## Recommended Import Shape
+
+Use concise conclusions such as:
+
+- durable user preferences
+- project conventions and source-of-truth rules
+- recurring local machine or toolchain gotchas
+- failure patterns with known fixes
+- curated learnings from `memory_summary.md`
+
+Avoid:
+
+- raw session messages
+- unreviewed rollout summaries
+- stale "it works" claims without the original date
+- generated artifacts that were meant only for a one-off task
+
+## Suggested Sets
+
+| Set | Includes | Use when |
+| --- | --- | --- |
+| `core` | global preferences plus the highest-signal reusable rules | you want the smallest first import |
+| `high` | high-priority preferences, tips, and curated learnings | you want a conservative import |
+| `high-medium` | high plus repo facts and failure/fix patterns | you want a useful first bootstrap |
+| `full` | everything above plus low-priority topic routes | you want Honcho to act as a broad memory router |
+
+The recommended first import is usually `high-medium`.
+
+## Preserve Chronology
+
+Honcho conclusion `createdAt` is the upload time. Do not try to backdate it.
+
+Instead, preserve source chronology in the conclusion text or metadata that your
+importer stages for review:
+
+```text
+Use `web/` as the JobBot build surface; the repository root has no package.json.
+[Source memory date: 2026-06-17; basis: latest rollout evidence.]
+```
+
+Common date sources:
+
+- `rollout_summaries/YYYY-MM-DD...` filenames
+- dated headings in `memory_summary.md`
+- the memory-summary snapshot date for global profile/preference rows
+
+## Route Sessions Deliberately
+
+For project-specific conclusions, route to the same session naming strategy that
+`codex-honcho` uses:
+
+- `per-directory`: `basename(cwd)`
+- `git-branch`: `basename(cwd)-branch`
+- explicit `sessions[cwd]` overrides from `~/.honcho/config.json`
+
+Global preferences should remain unscoped peer conclusions.
+
+## Preflight Before Upload
+
+Before creating conclusions, compare the staged upload text against existing
+Honcho conclusions and skip exact matches.
+
+When checking a large conclusion set, do not rely on a single paginated list
+pass if ordering is unstable. A safer preflight can union multiple list orders
+or use targeted lookups for representative rows.
+
+## Review Checklist
+
+Before upload, confirm:
+
+- the import set is intentionally scoped (`core`, `high`, `high-medium`, or
+  `full`)
+- every row has clean review text and exact upload text
+- project rows have the intended Honcho session id
+- source dates are present for old conclusions
+- exact duplicates are skipped
+- upload is impossible without explicit user approval
+

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bin",
     "src",
     "skills",
+    "examples",
     "install.sh",
     "README.md",
     "CHANGELOG.md",


### PR DESCRIPTION
## Summary
- document an optional docs-first workflow for bootstrapping existing Codex memory into Honcho
- add an examples/bootstrap-codex-memory checklist covering safe import shape, source-date chronology, routing, preflight, and review checks
- include examples in package files and ignore honcho-bootstrap dry-run output folders

## Why
codex-honcho install captures future sessions, but users with existing ~/.codex/memories need a safe migration path. This keeps bootstrap separate from install, avoids raw transcript imports, and makes explicit approval/source-date preservation part of the recommended workflow.

## Validation
- git diff --check
- npm run typecheck
- npm run build
- npm pack --dry-run

Not run:
- bun test (bun is not installed in this environment)