### PR TITLE
docs: fix language to match MCP server

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
   "interface": {
     "displayName": "Codex Honcho",
     "shortDescription": "Persistent cross-session memory for Codex, powered by Honcho.",
-    "longDescription": "Give Codex long-term memory that survives context resets, session restarts, and fresh conversations. Lifecycle hooks capture each session to Honcho and inject the relevant context back at session start, so Codex remembers what you are working on, your preferences, and the decisions you have made across every project. A bundled honcho-memory skill nudges Codex to recall and save actively, and the hosted Honcho MCP server (search, chat, get_context, create_conclusion) lets it query and update memory mid-task. Conversations are queued to disk instantly and uploaded in the background, so capture never blocks your turn. Install via npm (npm install -g @honcho-ai/codex-honcho && codex-honcho install).",
+    "longDescription": "Give Codex long-term memory that survives context resets, session restarts, and fresh conversations. Lifecycle hooks capture each session to Honcho and inject the relevant context back at session start, so Codex remembers what you are working on, your preferences, and the decisions you have made across every project. A bundled honcho-memory skill nudges Codex to recall and save actively, and the hosted Honcho MCP server (search, chat, get_peer_context, create_conclusions) lets it query and update memory mid-task. Conversations are queued to disk instantly and uploaded in the background, so capture never blocks your turn. Install via npm (npm install -g @honcho-ai/codex-honcho && codex-honcho install).",
     "developerName": "Plastic Labs",
     "category": "Productivity",
     "capabilities": [

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The bundled `honcho-memory` skill already nudges Codex to recall and save active
 You have persistent memory via Honcho. Context about me is loaded at the start
 of every session — trust it and act on it; don't ask me what you already know.
 Use the Honcho MCP tools (`search`, `chat`) to recall more mid-task, and
-`create_conclusion` to save new preferences, decisions, and patterns as you learn them.
+`create_conclusions` to save new preferences, decisions, and patterns as you learn them.
 ```
 
 ## MCP Tools
@@ -87,12 +87,12 @@ Once installed, Codex can call these Honcho tools directly:
 | --------------------- | --------------------------------------------------- |
 | `search`              | Semantic search across your session messages        |
 | `chat`                | Ask Honcho a natural-language question about you     |
-| `get_context`         | Fetch the current model of you (representation + card) |
+| `get_peer_context`    | Fetch the current model of you (representation + peer card) |
 | `get_representation`  | Lightweight representation string                   |
-| `create_conclusion`   | Save a durable insight to memory                     |
+| `create_conclusions`  | Save durable insights to memory                      |
 | `list_conclusions`    | List saved conclusions                              |
+| `query_conclusions`   | Semantic search across derived conclusions          |
 | `delete_conclusion`   | Remove a conclusion by ID                           |
-| `get_config` / `set_config` | View or change configuration                  |
 
 ## Commands
 

--- a/skills/honcho-memory/SKILL.md
+++ b/skills/honcho-memory/SKILL.md
@@ -19,12 +19,12 @@ Before non-trivial work, query memory instead of guessing:
 Use the Honcho MCP tools:
 
 - `search` — semantic lookup over past messages
-- `get_context` / `get_representation` — the current model of the user
+- `get_peer_context` / `get_representation` — the current model of the user
 - `chat` — ask a natural-language question about the user ("what's their testing style?")
 
 ## When to save memory
 
-After you learn something durable, persist it with `create_conclusion`:
+After you learn something durable, persist it with `create_conclusions`:
 
 - A decision with rationale ("chose SQLite over Postgres — embedded, zero-setup")
 - A stable preference ("prefers small, focused PRs")

--- a/src/connectors/mcp.ts
+++ b/src/connectors/mcp.ts
@@ -5,7 +5,7 @@ import { DEFAULT_CONFIG_PATH } from "./codex.ts";
 // Honcho runs a hosted MCP server at https://mcp.honcho.dev (streamable HTTP,
 // verified at the bare root — /mcp 404s). Rather than ship our own, we register
 // it in ~/.codex/config.toml so Codex gets the active recall tools
-// (search/chat/get_context/...). Auth + identity ride as static http_headers
+// (search/chat/get_peer_context/...). Auth + identity ride as static http_headers
 // read from ~/.honcho/config.json at install (Authorization + X-Honcho-*).
 
 export const HONCHO_MCP_URL = "https://mcp.honcho.dev";

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -13,7 +13,7 @@ const MAX_CONCLUSIONS = 8;
 // Injected once at session start so the model actively queries memory through
 // the Honcho MCP tools rather than leaning on heavy per-turn injection.
 const TOOL_HINT =
-  "Honcho memory tools are available via MCP — call honcho search / get_context to recall facts " +
+  "Honcho memory tools are available via MCP — call honcho search / get_peer_context to recall facts " +
   "across sessions, and honcho chat for questions about the user's history. Prefer querying over guessing.";
 
 // SessionStart: materialize the session and surface a lean snapshot of what we


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance and examples to use the corrected memory tool names.
  * Clarified the available MCP tools and refreshed the tool list in the README.
  * Adjusted plugin and skill instructions to match the latest naming for memory retrieval and saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->