### PR TITLE
Repo-local .honcho configuration and per-repo sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@ node_modules/
 dist/
 *.log
 .DS_Store
+.env
+.env.*
+!.env.example
 .honcho/
 bun.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Add read-only repo-local `.honcho/config.json` overlays with nearest-ancestor discovery, global-field inheritance, project-root session anchoring, optional pinned session names, and optional nested git-repository splitting.
+- Run the Honcho MCP as a credential-free local stdio server so hooks and active-recall tools use the same repo-local endpoint, workspace, and identity.
+- Namespace local queue, cursor, and context keys by workspace to prevent messages captured before an override from crossing memory scopes.
+- Add the Hermes-compatible `per-repo` session strategy: all directories in a Git repository share the Git root's session name, with a per-directory fallback outside Git.
+
 ## 0.1.0
 
 - Initial release — harness-level Honcho memory for OpenAI Codex.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Give Codex long-term memory that survives context resets, session restarts, and 
 - **Survives Context Resets** — Memory persists through `/clear`, compaction, and restarts
 - **Active Recall** — Codex can search your history and query what Honcho knows about you mid-task, not just at startup
 - **Git Awareness** — Optionally scope memory per branch, so feature work keeps its own context
-- **Flexible Sessions** — Map memory per directory, per git branch, or per chat instance
+- **Flexible Sessions** — Map memory per directory, per repository, per git branch, or per chat instance
+- **Per-Repo Isolation** — Route a repository to its own Honcho workspace with a checked-in `.honcho/config.json`
 - **Local-First Capture** — Conversations are queued to disk instantly and uploaded in the background — capture never blocks your turn or hits the network mid-conversation
 - **Cross-Tool Context** — Shares `~/.honcho/config.json` with other Honcho integrations (Claude Code, Cursor, …), so context can follow you between tools
 
@@ -60,7 +61,7 @@ npm install -g @honcho-ai/codex-honcho
 codex-honcho install      # registers hooks + MCP + skill in ~/.codex
 ```
 
-`install` copies your resolved key into `~/.codex/config.toml` so the Honcho MCP server authenticates with no environment variable to set. If you ever rotate your key, re-run `codex-honcho install` to refresh it.
+`install` registers a local MCP server in `~/.codex/config.toml`. The server reads the active Honcho config at runtime, so API keys never appear in Codex's config and repo-local workspace/endpoint overrides apply to MCP tools as well as hooks. Restart Codex after rotating a key or changing configuration.
 
 ### Step 4: Restart Codex
 
@@ -81,7 +82,7 @@ Use the Honcho MCP tools (`search`, `chat`) to recall more mid-task, and
 
 ## MCP Tools
 
-Once installed, Codex can call these Honcho tools directly:
+Once installed, Codex can call these Honcho tools through the local MCP server:
 
 | Tool                  | Description                                          |
 | --------------------- | --------------------------------------------------- |
@@ -104,7 +105,7 @@ Once installed, Codex can call these Honcho tools directly:
 
 ## Configuration
 
-All settings live in `~/.honcho/config.json` (shared with other Honcho integrations). Codex-specific settings go under `hosts.codex`, falling back to the root fields. The hooks only ever read this file; `install` is the only writer.
+Global defaults live in `~/.honcho/config.json` (shared with other Honcho integrations). Codex-specific settings go under `hosts.codex`, falling back to the root fields. Hooks and the MCP server only read configuration at runtime; `install` is the only writer, and it writes only resolved global credentials/identity back to the shared file.
 
 ```jsonc
 {
@@ -121,6 +122,46 @@ All settings live in `~/.honcho/config.json` (shared with other Honcho integrati
 }
 ```
 
+### Repo-Local Configuration
+
+Place `.honcho/config.json` in a repository to override selected global values for that project. The nearest file at or above Codex's working directory wins, so one file at the repository root covers the whole tree and a nested file can carve out a more specific scope.
+
+The local file is an overlay, not a replacement. This is usually all a repository needs:
+
+```jsonc
+// <repo>/.honcho/config.json
+{
+  "workspace": "my-project"
+}
+```
+
+`apiKey`, `peerName`, `endpoint`, and any other omitted values continue to come from `~/.honcho/config.json`. The same host-aware shape works too:
+
+```jsonc
+{
+  "hosts": {
+    "codex": {
+      "workspace": "my-project",
+      "sessionStrategy": "per-repo"
+    }
+  }
+}
+```
+
+Repo-local configuration is read-only to codex-honcho: the plugin never writes it or copies its values into the global file. Keep secrets out of repositories; a committed local config should normally contain only non-secret routing/session settings. A self-contained local config with its own `apiKey` is supported when no global config exists, but the file should then remain untracked and appropriately protected.
+
+With a local config active, session identity anchors to the directory containing `.honcho/` instead of whichever subfolder Codex is currently using. Optional local-only fields provide more control:
+
+```jsonc
+{
+  "workspace": "my-project",
+  "sessionName": "shared-project-memory", // pin one exact session name
+  "splitSubmodules": true                 // split nested git repos under other strategies
+}
+```
+
+The local MCP server is launched in Codex's active working directory, resolves the same nearest config, and calls Honcho through the SDK with the resolved endpoint, workspace, and identity. Restart Codex after adding or changing `.honcho/config.json` so its MCP process reconnects with the new values.
+
 ### Session Strategies
 
 Controls how Codex conversations map to Honcho sessions:
@@ -128,10 +169,13 @@ Controls how Codex conversations map to Honcho sessions:
 | Strategy | Session name | Best for |
 | --- | --- | --- |
 | `per-directory` (default) | `my-app` | Most users — each project accumulates its own memory |
+| `per-repo` | `my-app` | One memory session for every directory in the same Git repository |
 | `git-branch` | `my-app-main` | Feature-branch workflows where context per branch matters |
 | `chat-instance` | `my-app-019ea7df` | Ephemeral usage — a clean slate per conversation |
 
-An explicit `sessions[cwd]` mapping overrides all strategies. Environment overrides: `HONCHO_API_KEY`, `HONCHO_PEER_NAME`, `HONCHO_CONFIG_DIR`.
+`per-repo` matches the Hermes Honcho provider: it uses the Git root directory name, so launching Codex from `src/`, `packages/app/`, or the repository root resolves to the same session. Outside a Git repository it falls back to `per-directory`. A nested repository or worktree with its own `.git` file/directory gets its own session; with repo-local configuration, discovery stays inside that configuration's project root.
+
+On the global-only path, an explicit `sessions[cwd]` mapping overrides all strategies. Repo-local configuration instead anchors sessions to its project root as described above. Environment overrides: `HONCHO_API_KEY`, `HONCHO_PEER_NAME`, `HONCHO_CONFIG_DIR`.
 
 ## How It Works
 
@@ -164,6 +208,8 @@ The plugin hooks into Codex's lifecycle events:
 
 Capture is **local-first**: hooks only ever append to a plain JSONL queue, so they're instant and never touch the network. The flush is lock-guarded and advances a per-chunk sent marker, so a failed or partial upload simply stays queued and retries on the next turn. Inspect the local queue any time with `tail -f ~/.honcho/codex/queue/*.jsonl`, and run `codex-honcho status` to see the pending depth plus a deep link to your session in the Honcho GUI to confirm what landed server-side.
 
+When repo-local configuration is active, local queue/cache keys include its resolved workspace. Turning on an override therefore cannot flush previously queued global-session messages into the project workspace.
+
 ## Troubleshooting
 
 **No memory loading / MCP not registered.** Confirm your key is in `~/.honcho/config.json` (`codex-honcho status` shows `honcho config: found`). If it's missing, run `honcho init` (or add `{ "apiKey": "hch-…" }` to the file yourself), then re-run `codex-honcho install` — without a key, install registers the hooks and skill but skips the MCP server.
@@ -172,13 +218,15 @@ Capture is **local-first**: hooks only ever append to a plain JSONL queue, so th
 
 **Memory not persisting.** Make sure `saveMessages` isn't set to `false` under `hosts.codex`.
 
+**Repo-local config not taking effect.** Run `codex-honcho status` from the repository; it prints the active local config path when one is found. Restart Codex after changing the file so the MCP server reconnects with the same resolved workspace used by hooks.
+
 ## What Install Writes
 
 | Path | Change |
 |---|---|
 | `~/.codex/honcho/` | staged copy of the bundle the hooks run (kept stable across npm/npx cache eviction) |
 | `~/.codex/hooks.json` | adds the four hook entries (merged; your own hooks untouched) |
-| `~/.codex/config.toml` | sets `[features].hooks = true`; registers `[mcp_servers.honcho]` → `mcp.honcho.dev` (native HTTP) |
+| `~/.codex/config.toml` | sets `[features].hooks = true`; registers `[mcp_servers.honcho]` as a credential-free local stdio server |
 | `~/.codex/skills/honcho-memory/` | the active-recall skill |
 | `~/.honcho/config.json` | persists the resolved `apiKey` + `peerName` (other fields and `hosts.*` blocks preserved) |
 
@@ -204,7 +252,8 @@ src/transcript/codex.ts  Codex rollout (.jsonl) parser
 src/queue.ts             append-only outbox + sent high-water-mark
 src/cursor.ts            per-conversation rollout delta cursor
 src/connectors/          hooks.json · config.toml MCP block · skill writers
-src/config.ts            hosts.codex resolution; session naming
+src/config.ts            global + repo-local resolution; session naming
+src/mcp.ts               cwd-aware local MCP server backed by the Honcho SDK
 skills/honcho-memory/    when-to-recall guidance for the model
 ```
 

--- a/bin/codex-honcho.ts
+++ b/bin/codex-honcho.ts
@@ -10,10 +10,11 @@ import {
   DEFAULT_HOOKS_PATH,
   DEFAULT_CONFIG_PATH,
 } from "../src/connectors/codex.ts";
-import { installMcpServer, removeMcpServer, type McpIdentity } from "../src/connectors/mcp.ts";
+import { installMcpServer, removeMcpServer, type McpCommand } from "../src/connectors/mcp.ts";
 import { installSkill, removeSkill, hasSkill } from "../src/connectors/skill.ts";
 import { loadConfig, memoryKey, currentIdentity, saveConfig, resolvePeerName, sessionName, honchoSessionUrl } from "../src/config.ts";
 import { pendingCount } from "../src/queue.ts";
+import { runMcpServer } from "../src/mcp.ts";
 
 const command = process.argv[2] ?? "";
 
@@ -50,17 +51,6 @@ async function runHook(verb: string): Promise<void> {
   }
 }
 
-function mcpIdentity(): McpIdentity | null {
-  const config = loadConfig();
-  if (!config) return null;
-  return {
-    apiKey: config.apiKey,
-    userName: config.peerName,
-    workspaceId: config.workspace,
-    assistantName: config.aiPeer,
-  };
-}
-
 // The shell command each Codex hook runs. Wire hooks to an entry's *absolute*
 // path (PATH-independent; Codex's hook runner may have a minimal PATH). The
 // bundled build is JS run under `node` (no bun required); a local/dev clone is
@@ -68,6 +58,12 @@ function mcpIdentity(): McpIdentity | null {
 function hookInvoke(entry: string): (verb: string) => string {
   const runner = entry.endsWith(".ts") ? "bun run" : "node";
   return (verb) => `${runner} ${JSON.stringify(entry)} ${verb}`;
+}
+
+function mcpInvoke(entry: string): McpCommand {
+  return entry.endsWith(".ts")
+    ? { command: "bun", args: ["run", entry, "mcp"] }
+    : { command: "node", args: [entry, "mcp"] };
 }
 
 // Resolve the entry the hooks should point at. A dev/clone `.ts` entry lives in
@@ -116,10 +112,9 @@ switch (command) {
     console.log(`Installed Codex hooks → ${DEFAULT_HOOKS_PATH}`);
     console.log(`Enabled [features].hooks → ${DEFAULT_CONFIG_PATH}`);
     console.log(`Installed memory skill → ${installSkill()}`);
-    const id = mcpIdentity();
-    if (id) {
-      installMcpServer(id);
-      console.log(`Registered Honcho MCP (mcp.honcho.dev) → ${DEFAULT_CONFIG_PATH}`);
+    if (loadConfig(process.cwd())) {
+      installMcpServer(mcpInvoke(entry));
+      console.log(`Registered Honcho MCP server → ${DEFAULT_CONFIG_PATH}`);
     } else {
       console.log("Skipped MCP registration — no Honcho API key found. Run `honcho init`, then re-run install.");
     }
@@ -140,9 +135,10 @@ switch (command) {
   case "status": {
     console.log(hasCodexHooks() ? "codex-honcho hooks: installed" : "codex-honcho hooks: not installed");
     console.log(hasSkill() ? "memory skill: installed" : "memory skill: not installed");
-    const cfg = loadConfig();
+    const cfg = loadConfig(process.cwd());
     console.log(cfg ? "honcho config: found" : "honcho config: missing (run `honcho init`)");
     if (cfg) {
+      if (cfg.localConfig) console.log(`repo-local config: ${cfg.localConfig.path}`);
       const key = memoryKey(cfg, process.cwd());
       console.log(`queue (${key}): ${pendingCount(key)} pending upload`);
       // Deep link to inspect what actually landed server-side. We have no live
@@ -156,8 +152,11 @@ switch (command) {
     }
     break;
   }
+  case "mcp":
+    await runMcpServer(process.cwd());
+    break;
   default:
     await runHook(command);
 }
 
-process.exit(0);
+if (command !== "mcp") process.exit(0);

--- a/build.mjs
+++ b/build.mjs
@@ -1,7 +1,7 @@
 // Bundle the CLI + hooks into a single self-contained Node script so the hooks
-// run under `node` (no bun, no node_modules at the user's site). The Honcho SDK
-// is bundled in; the only runtime requirement becomes `node` (the MCP server is
-// registered as a native HTTP endpoint — no `npx`/mcp-remote bridge). Run via `npm run build`.
+// run under `node` (no bun, no node_modules at the user's site). The Honcho and
+// MCP SDKs are bundled in; the same artifact also runs the local stdio server
+// that resolves repo-local config before calling Honcho. Run via `npm run build`.
 import * as esbuild from "esbuild";
 import { rmSync, mkdirSync, copyFileSync } from "node:fs";
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,9 @@
 import { homedir } from "node:os";
-import { join, basename, dirname } from "node:path";
+import { join, basename, dirname, resolve, relative, isAbsolute, parse, sep } from "node:path";
 import { existsSync, readFileSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
 import { currentBranch } from "./git.ts";
 
-export type SessionStrategy = "per-directory" | "git-branch" | "chat-instance";
+export type SessionStrategy = "per-directory" | "per-repo" | "git-branch" | "chat-instance";
 
 // codex-honcho shares the ~/.honcho/config.json file with the other Honcho
 // integrations. Codex-specific settings live under hosts.codex; root fields
@@ -32,6 +32,8 @@ interface HostBlock {
   reasoningLevel?: string;
   injectPerPrompt?: boolean;
   sessionStrategy?: SessionStrategy;
+  sessionName?: string;
+  splitSubmodules?: boolean;
   endpoint?: { environment?: "production" | "local"; baseUrl?: string };
 }
 
@@ -55,11 +57,22 @@ export interface Config {
   injectPerPrompt: boolean;
   // How Honcho session names are derived (default per-directory).
   sessionStrategy: SessionStrategy;
+  // Repo-local only: pin the project to one exact session name.
+  sessionName?: string;
+  // Repo-local only: anchor nested git repositories to their own sessions.
+  splitSubmodules?: boolean;
   endpoint?: { environment?: "production" | "local"; baseUrl?: string };
   sessions?: Record<string, string>;
+  // Present only when this config includes a repo-local overlay.
+  localConfig?: LocalConfigInfo;
 }
 
-function readFile(): FileConfig {
+export interface LocalConfigInfo {
+  path: string;
+  root: string;
+}
+
+function readGlobalFile(): FileConfig {
   const path = configPath();
   if (!existsSync(path)) return {};
   try {
@@ -76,9 +89,7 @@ export function resolvePeerName(filePeer?: string): string {
   return filePeer || process.env.HONCHO_PEER_NAME || process.env.USER || process.env.USERNAME || "user";
 }
 
-// Returns null when there's no API key — callers exit quietly in that case.
-export function loadConfig(): Config | null {
-  const raw = readFile();
+function resolveFileConfig(raw: FileConfig): Config | null {
   const host = raw.hosts?.[HOST];
 
   const apiKey = process.env.HONCHO_API_KEY || host?.apiKey || raw.apiKey;
@@ -108,10 +119,89 @@ export function loadConfig(): Config | null {
   };
 }
 
+const LOCAL_FIELDS = [
+  "apiKey",
+  "peerName",
+  "workspace",
+  "aiPeer",
+  "enabled",
+  "saveMessages",
+  "reasoningLevel",
+  "injectPerPrompt",
+  "sessionStrategy",
+  "sessionName",
+  "splitSubmodules",
+  "endpoint",
+] as const;
+
+// Walk upward from cwd to the nearest project-owned .honcho/config.json. The
+// shared global config is never treated as a local overlay, including when its
+// directory is redirected with HONCHO_CONFIG_DIR.
+export function findLocalConfig(cwd: string): LocalConfigInfo | null {
+  try {
+    const home = resolve(homedir());
+    const globalPath = resolve(configPath());
+    let dir = resolve(cwd);
+    for (let depth = 0; depth < 64; depth++) {
+      const path = join(dir, ".honcho", "config.json");
+      if (dir !== home && resolve(path) !== globalPath && existsSync(path)) {
+        return { path, root: dir };
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Invalid or inaccessible cwd: preserve global-only behavior.
+  }
+  return null;
+}
+
+function localField(raw: FileConfig, key: (typeof LOCAL_FIELDS)[number]): unknown {
+  const host = raw.hosts?.[HOST] as Record<string, unknown> | undefined;
+  return host?.[key] ?? (raw as unknown as Record<string, unknown>)[key];
+}
+
+function applyLocalConfig(base: Config | null, local: LocalConfigInfo | null): Config | null {
+  if (!local) return base;
+
+  let raw: FileConfig;
+  try {
+    raw = JSON.parse(readFileSync(local.path, "utf-8")) as FileConfig;
+  } catch {
+    return base;
+  }
+
+  // A local file normally inherits credentials and identity from the shared
+  // config, but it can also be fully self-contained when no global config is
+  // available.
+  const effective = base ? { ...base } : resolveFileConfig(raw);
+  if (!effective) return base;
+
+  for (const key of LOCAL_FIELDS) {
+    const value = localField(raw, key);
+    if (value !== undefined) (effective as unknown as Record<string, unknown>)[key] = value;
+  }
+  // Preserve the existing explicit environment override above both config
+  // files; a repo-local apiKey still works when HONCHO_API_KEY is absent.
+  if (process.env.HONCHO_API_KEY) effective.apiKey = process.env.HONCHO_API_KEY;
+  if (!effective.apiKey) return base;
+  effective.localConfig = local;
+  return effective;
+}
+
+// Returns null when there's no API key — callers exit quietly in that case.
+// When cwd is inside a project with .honcho/config.json, that file overlays the
+// resolved global config field-by-field. Local values win; omitted values keep
+// inheriting from ~/.honcho/config.json.
+export function loadConfig(cwd: string = process.cwd()): Config | null {
+  return applyLocalConfig(resolveFileConfig(readGlobalFile()), findLocalConfig(cwd));
+}
+
 // The currently-resolved key + peer, read straight from env/file (no defaults
 // applied). `install` uses this to decide what's missing and must be prompted.
 export function currentIdentity(): { apiKey?: string; peerName?: string } {
-  const raw = readFile();
+  const raw = readGlobalFile();
   return {
     apiKey: process.env.HONCHO_API_KEY || raw.hosts?.[HOST]?.apiKey || raw.apiKey,
     peerName: raw.peerName,
@@ -124,7 +214,7 @@ export function currentIdentity(): { apiKey?: string; peerName?: string } {
 // and override a root-level `workspace` the user expects codex to inherit.
 // Returns the path written.
 export function saveConfig(patch: { apiKey?: string; peerName?: string }): string {
-  const raw = readFile();
+  const raw = readGlobalFile();
   if (patch.apiKey) raw.apiKey = patch.apiKey;
   if (patch.peerName) raw.peerName = patch.peerName;
 
@@ -160,24 +250,64 @@ function slug(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
 }
 
-// Honcho session name. An explicit sessions[cwd] override always wins; otherwise
-// derived per strategy:
+function withinRoot(path: string, root: string): boolean {
+  const rel = relative(root, path);
+  return rel === "" || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`));
+}
+
+// Find the nearest git root, optionally without escaping a repo-local config's
+// project root. A .git file counts too, which covers worktrees/submodules.
+export function findNearestGitRoot(cwd: string, projectRoot?: string): string | null {
+  try {
+    let dir = resolve(cwd);
+    const root = projectRoot ? resolve(projectRoot) : parse(dir).root;
+    if (!withinRoot(dir, root)) return null;
+    for (let depth = 0; depth < 64; depth++) {
+      if (existsSync(join(dir, ".git"))) return dir;
+      if (dir === root) break;
+      const parent = dirname(dir);
+      if (parent === dir || !withinRoot(parent, root)) break;
+      dir = parent;
+    }
+  } catch {
+    // Fall back to the project root in sessionName().
+  }
+  return null;
+}
+
+// Honcho session name. On the global-only path an explicit sessions[cwd]
+// override wins; repo-local configs anchor to their project root instead.
+// Otherwise names are derived per strategy:
 //   per-directory  → <repo>                 (one session per project dir)
+//   per-repo       → <git root>             (one session per git repository)
 //   git-branch     → <repo>-<branch>        (per branch; falls back to repo)
 //   chat-instance  → <repo>-<short id>      (one session per Codex conversation)
 // No peer prefix — the workspace already isolates a user's data.
 export function sessionName(config: Config, cwd: string, sessionId?: string): string {
-  const override = config.sessions?.[cwd];
-  if (override) return override;
+  const local = config.localConfig;
+  if (!local) {
+    const override = config.sessions?.[cwd];
+    if (override) return override;
+  }
 
-  const repo = slug(basename(cwd));
+  if (local && config.sessionName) return slug(config.sessionName);
+
+  const directoryAnchor = local?.root ?? cwd;
+  const anchor = config.sessionStrategy === "per-repo"
+    ? findNearestGitRoot(cwd, local?.root) ?? directoryAnchor
+    : local && config.splitSubmodules
+      ? findNearestGitRoot(cwd, local.root) ?? local.root
+      : directoryAnchor;
+
+  const repo = slug(basename(anchor));
   switch (config.sessionStrategy) {
     case "git-branch": {
-      const branch = currentBranch(cwd);
+      const branch = currentBranch(anchor);
       return branch ? `${repo}-${slug(branch)}` : repo;
     }
     case "chat-instance":
       return sessionId ? `${repo}-${slug(sessionId).slice(0, 8)}` : repo;
+    case "per-repo":
     case "per-directory":
     default:
       return repo;
@@ -187,7 +317,11 @@ export function sessionName(config: Config, cwd: string, sessionId?: string): st
 // Stable key for cursor/cache/queue files: the Codex session id when present,
 // else the derived session name.
 export function memoryKey(config: Config, cwd: string, sessionId?: string): string {
-  return sessionId || sessionName(config, cwd, sessionId);
+  const key = sessionId || sessionName(config, cwd, sessionId);
+  // Keep queues/cursors/context from an existing global session out of a newly
+  // activated repo-local workspace. The default path remains byte-for-byte
+  // compatible with prior releases.
+  return config.localConfig ? `local-${config.workspace}-${key}` : key;
 }
 
 // Deep link into the Honcho GUI for a given session. The web app lives at the

--- a/src/connectors/mcp.ts
+++ b/src/connectors/mcp.ts
@@ -2,24 +2,18 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { DEFAULT_CONFIG_PATH } from "./codex.ts";
 
-// Honcho runs a hosted MCP server at https://mcp.honcho.dev (streamable HTTP,
-// verified at the bare root — /mcp 404s). Rather than ship our own, we register
-// it in ~/.codex/config.toml so Codex gets the active recall tools
-// (search/chat/get_peer_context/...). Auth + identity ride as static http_headers
-// read from ~/.honcho/config.json at install (Authorization + X-Honcho-*).
-
-export const HONCHO_MCP_URL = "https://mcp.honcho.dev";
+// Codex launches our local stdio MCP server. It resolves the active cwd's Honcho
+// config and calls the SDK directly, so repo-local workspace and endpoint values
+// apply without putting credentials in config.toml.
 
 // We own a fenced region of config.toml so we can rewrite/remove it cleanly
 // without parsing the whole TOML document.
 const BLOCK_START = "# >>> codex-honcho (honcho mcp) >>>";
 const BLOCK_END = "# <<< codex-honcho (honcho mcp) <<<";
 
-export interface McpIdentity {
-  apiKey: string;
-  userName: string;
-  workspaceId?: string;
-  assistantName?: string;
+export interface McpCommand {
+  command: string;
+  args: string[];
 }
 
 // TOML basic strings use the same escaping as JSON for our inputs (keys, names,
@@ -28,24 +22,12 @@ function tomlString(value: string): string {
   return JSON.stringify(value);
 }
 
-function buildBlock(id: McpIdentity): string {
-  // Auth + identity all ride as static http_headers. Codex rejects a top-level
-  // `bearer_token` for streamable_http servers ("not supported"), so we send the
-  // key as an inline `Authorization: Bearer …` header instead — same wire result,
-  // and it keeps the zero-env-var install (key read from ~/.honcho/config.json).
-  // X-Honcho-User-Name is required; workspace/assistant are optional.
-  const headers = [
-    `"Authorization" = ${tomlString(`Bearer ${id.apiKey}`)}`,
-    `"X-Honcho-User-Name" = ${tomlString(id.userName)}`,
-  ];
-  if (id.workspaceId) headers.push(`"X-Honcho-Workspace-ID" = ${tomlString(id.workspaceId)}`);
-  if (id.assistantName) headers.push(`"X-Honcho-Assistant-Name" = ${tomlString(id.assistantName)}`);
-
+function buildBlock(invoke: McpCommand): string {
   return [
     BLOCK_START,
     "[mcp_servers.honcho]",
-    `url = ${tomlString(HONCHO_MCP_URL)}`,
-    `http_headers = { ${headers.join(", ")} }`,
+    `command = ${tomlString(invoke.command)}`,
+    `args = ${JSON.stringify(invoke.args)}`,
     BLOCK_END,
   ].join("\n");
 }
@@ -61,9 +43,9 @@ function stripBlock(content: string): string {
 }
 
 // Replace any existing block with a fresh one; idempotent.
-export function setMcpServer(content: string, id: McpIdentity): string {
+export function setMcpServer(content: string, invoke: McpCommand): string {
   const base = stripBlock(content).trimEnd();
-  const block = buildBlock(id);
+  const block = buildBlock(invoke);
   return base ? `${base}\n\n${block}\n` : `${block}\n`;
 }
 
@@ -75,10 +57,10 @@ export function hasMcpServer(content: string): boolean {
   return content.includes(BLOCK_START);
 }
 
-export function installMcpServer(id: McpIdentity, configPath: string = DEFAULT_CONFIG_PATH): void {
+export function installMcpServer(invoke: McpCommand, configPath: string = DEFAULT_CONFIG_PATH): void {
   mkdirSync(dirname(configPath), { recursive: true });
   const existing = existsSync(configPath) ? readFileSync(configPath, "utf-8") : "";
-  writeFileSync(configPath, setMcpServer(existing, id));
+  writeFileSync(configPath, setMcpServer(existing, invoke));
 }
 
 export function removeMcpServer(configPath: string = DEFAULT_CONFIG_PATH): boolean {

--- a/src/hooks/flush.ts
+++ b/src/hooks/flush.ts
@@ -109,10 +109,10 @@ function releaseLock(key: string): void {
 // Background worker: drain pending queue entries to Honcho, in order, and
 // advance the sent marker only on success so failures retry next time.
 export async function flush(input: FlushInput): Promise<string> {
-  const config = loadConfig();
+  const cwd = input.cwd || process.cwd();
+  const config = loadConfig(cwd);
   if (!config || !config.enabled || !config.saveMessages) return "";
 
-  const cwd = input.cwd || process.cwd();
   const name = sessionName(config, cwd, input.session_id);
   const key = memoryKey(config, cwd, input.session_id);
 

--- a/src/hooks/observe.ts
+++ b/src/hooks/observe.ts
@@ -59,13 +59,13 @@ export function summarizeTool(name: string, input: Record<string, unknown>): str
 // only — instant, no network. The next writeback (Stop) flushes it along with
 // the turn, so frequent tool calls never trigger an upload of their own.
 export async function observe(input: ObserveInput): Promise<string> {
-  const config = loadConfig();
+  const cwd = input.cwd || process.cwd();
+  const config = loadConfig(cwd);
   if (!config || !config.enabled || !config.saveMessages) return "";
 
   const summary = summarizeTool(input.tool_name ?? "", input.tool_input ?? {});
   if (!summary) return "";
 
-  const cwd = input.cwd || process.cwd();
   enqueue(memoryKey(config, cwd, input.session_id), [{ role: "tool", text: summary, at: new Date().toISOString() }]);
   return "";
 }

--- a/src/hooks/prompt.ts
+++ b/src/hooks/prompt.ts
@@ -14,13 +14,13 @@ const TRIVIAL = /^(y|n|yes|no|ok|okay|sure|thanks|yep|nope|continue|go ahead|do 
 // cover recall without taxing every turn. When injectPerPrompt is enabled,
 // serve the cached snapshot (no network) and never repeat the same block.
 export async function prompt(input: PromptInput): Promise<string> {
-  const config = loadConfig();
+  const cwd = input.cwd || process.cwd();
+  const config = loadConfig(cwd);
   if (!config || !config.enabled || !config.injectPerPrompt) return "";
 
   const text = (input.prompt ?? "").trim();
   if (!text || TRIVIAL.test(text)) return "";
 
-  const cwd = input.cwd || process.cwd();
   const key = memoryKey(config, cwd, input.session_id);
 
   const cached = readContext(key);

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -19,10 +19,10 @@ const TOOL_HINT =
 // SessionStart: materialize the session and surface a lean snapshot of what we
 // know, plus a nudge to use the MCP tools for anything deeper.
 export async function recall(input: RecallInput): Promise<string> {
-  const config = loadConfig();
+  const cwd = input.cwd || process.cwd();
+  const config = loadConfig(cwd);
   if (!config || !config.enabled) return "";
 
-  const cwd = input.cwd || process.cwd();
   const name = sessionName(config, cwd, input.session_id);
   const key = memoryKey(config, cwd, input.session_id);
 

--- a/src/hooks/writeback.ts
+++ b/src/hooks/writeback.ts
@@ -27,11 +27,11 @@ export function capture(key: string, rolloutPath: string): number {
 // already responded, so this brief upload doesn't lag the visible turn — and
 // it drains any observations queued during the turn too.
 export async function writeback(input: WritebackInput): Promise<string> {
-  const config = loadConfig();
+  const cwd = input.cwd || process.cwd();
+  const config = loadConfig(cwd);
   if (!config || !config.enabled || !config.saveMessages) return "";
   if (!input.transcript_path) return "";
 
-  const cwd = input.cwd || process.cwd();
   capture(memoryKey(config, cwd, input.session_id), input.transcript_path);
   await flush({ cwd, session_id: input.session_id });
   return "";

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,0 +1,261 @@
+import { Honcho } from "@honcho-ai/sdk";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { honchoClientOptions, loadConfig } from "./config.ts";
+
+// Match the hosted Honcho MCP's core memory-tool interface so existing prompts
+// and the bundled skill keep working, while routing through the resolved local
+// SDK endpoint instead of fixed hosted HTTP credentials.
+export const HONCHO_TOOLS = [
+  {
+    name: "search",
+    description: "Semantic search across messages. With no scope params, searches the active workspace; peer_id or session_id narrows the search.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        query: { type: "string", description: "Search query." },
+        peer_id: { type: "string", description: "Optional: scope to messages authored by this peer." },
+        session_id: { type: "string", description: "Optional: scope to messages in this session." },
+      },
+      required: ["query"],
+    },
+    annotations: { readOnlyHint: true },
+  },
+  {
+    name: "chat",
+    description: "Ask a natural-language question about a peer's knowledge using Honcho's reasoning system.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        peer_id: { type: "string", description: "The peer to query." },
+        query: { type: "string", description: "Natural-language question." },
+        target_peer_id: { type: "string", description: "Optional target for a directional representation query." },
+        session_id: { type: "string", description: "Optional session scope." },
+        reasoning_level: { type: "string", enum: ["minimal", "low", "medium", "high", "max"], description: "Reasoning effort." },
+      },
+      required: ["peer_id", "query"],
+    },
+    annotations: { readOnlyHint: true },
+  },
+  {
+    name: "get_peer_context",
+    description: "Get comprehensive context for a peer, including their representation and peer card.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        peer_id: { type: "string", description: "The observer peer." },
+        target_peer_id: { type: "string", description: "Optional target peer." },
+        search_query: { type: "string", description: "Optional semantic filter for conclusions." },
+        max_conclusions: { type: "number", description: "Optional maximum conclusions." },
+      },
+      required: ["peer_id"],
+    },
+    annotations: { readOnlyHint: true },
+  },
+  {
+    name: "get_representation",
+    description: "Get the formatted representation for a peer without the peer card.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        peer_id: { type: "string", description: "The observer peer." },
+        target_peer_id: { type: "string", description: "Optional target peer." },
+        session_id: { type: "string", description: "Optional session scope." },
+        search_query: { type: "string", description: "Optional semantic filter for conclusions." },
+        max_conclusions: { type: "number", description: "Optional maximum conclusions." },
+      },
+      required: ["peer_id"],
+    },
+    annotations: { readOnlyHint: true },
+  },
+  {
+    name: "list_conclusions",
+    description: "List conclusions that Honcho has saved about a peer.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        peer_id: { type: "string", description: "The observer peer." },
+        target_peer_id: { type: "string", description: "Optional target; defaults to self-conclusions." },
+      },
+      required: ["peer_id"],
+    },
+    annotations: { readOnlyHint: true },
+  },
+  {
+    name: "query_conclusions",
+    description: "Semantic search across a peer's conclusions.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        peer_id: { type: "string", description: "The observer peer." },
+        query: { type: "string", description: "Semantic search query." },
+        target_peer_id: { type: "string", description: "Optional target peer." },
+        top_k: { type: "number", description: "Maximum results." },
+      },
+      required: ["peer_id", "query"],
+    },
+    annotations: { readOnlyHint: true },
+  },
+  {
+    name: "create_conclusions",
+    description: "Manually save conclusions (facts or observations) about a peer.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        peer_id: { type: "string", description: "The observer peer." },
+        target_peer_id: { type: "string", description: "The peer the conclusions are about." },
+        conclusions: { type: "array", items: { type: "string" }, description: "Conclusion content strings." },
+        session_id: { type: "string", description: "Optional associated session." },
+      },
+      required: ["peer_id", "target_peer_id", "conclusions"],
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+  },
+  {
+    name: "delete_conclusion",
+    description: "Delete a specific conclusion by ID.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        peer_id: { type: "string", description: "The observer peer." },
+        target_peer_id: { type: "string", description: "The peer the conclusion is about." },
+        conclusion_id: { type: "string", description: "The conclusion to delete." },
+      },
+      required: ["peer_id", "target_peer_id", "conclusion_id"],
+    },
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
+  },
+];
+
+function json(value: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }] };
+}
+
+function text(value: string) {
+  return { content: [{ type: "text" as const, text: value }] };
+}
+
+function failure(error: unknown) {
+  return {
+    content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+    isError: true,
+  };
+}
+
+// Local stdio MCP server. Codex starts it in the active workspace when no cwd
+// override is configured, so process.cwd() identifies the nearest repo-local
+// .honcho/config.json and its project-specific endpoint/workspace.
+export async function runMcpServer(cwd: string = process.cwd()): Promise<void> {
+  const config = loadConfig(cwd);
+  if (!config || !config.enabled) throw new Error("Honcho is not configured for this workspace");
+
+  const honcho = new Honcho(honchoClientOptions(config));
+  const server = new Server(
+    { name: "codex-honcho", version: "0.1.0" },
+    {
+      capabilities: { tools: {} },
+      instructions: "Use these tools to recall and maintain Honcho memory. Prefer read-only lookup tools before creating or deleting conclusions.",
+    },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [...HONCHO_TOOLS] }));
+  server.setRequestHandler(CallToolRequestSchema, async ({ params }) => {
+    const args = params.arguments ?? {};
+    try {
+      switch (params.name) {
+        case "search": {
+          const query = String(args.query);
+          const messages = args.session_id
+            ? await (await honcho.session(String(args.session_id))).search(query)
+            : args.peer_id
+              ? await (await honcho.peer(String(args.peer_id))).search(query)
+              : await honcho.search(query);
+          return json(messages.map((message) => ({
+            id: message.id,
+            content: message.content,
+            peerId: message.peerId,
+            sessionId: message.sessionId,
+            createdAt: message.createdAt,
+          })));
+        }
+        case "chat": {
+          const peer = await honcho.peer(String(args.peer_id));
+          const session = args.session_id ? await honcho.session(String(args.session_id)) : undefined;
+          const response = await peer.chat(String(args.query), {
+            ...(args.target_peer_id ? { target: String(args.target_peer_id) } : {}),
+            ...(session ? { session } : {}),
+            reasoningLevel: args.reasoning_level ? String(args.reasoning_level) : config.reasoningLevel,
+          });
+          return text(response ?? "No response from Honcho");
+        }
+        case "get_peer_context": {
+          const peer = await honcho.peer(String(args.peer_id));
+          const context = await peer.context({
+            ...(args.target_peer_id ? { target: String(args.target_peer_id) } : {}),
+            ...(args.search_query ? { searchQuery: String(args.search_query) } : {}),
+            ...(typeof args.max_conclusions === "number" ? { maxConclusions: args.max_conclusions } : {}),
+            includeMostFrequent: true,
+          });
+          return json({
+            representation: context.representation,
+            peerCard: context.peerCard,
+            peerId: context.peerId,
+            targetId: context.targetId,
+          });
+        }
+        case "get_representation": {
+          const peer = await honcho.peer(String(args.peer_id));
+          const representation = await peer.representation({
+            ...(args.target_peer_id ? { target: String(args.target_peer_id) } : {}),
+            ...(args.session_id ? { session: String(args.session_id) } : {}),
+            ...(args.search_query ? { searchQuery: String(args.search_query) } : {}),
+            ...(typeof args.max_conclusions === "number" ? { maxConclusions: args.max_conclusions } : {}),
+            includeMostFrequent: true,
+          });
+          return text(representation);
+        }
+        case "list_conclusions": {
+          const peer = await honcho.peer(String(args.peer_id));
+          const scope = peer.conclusionsOf(String(args.target_peer_id ?? args.peer_id));
+          const result = await scope.list();
+          return json({
+            items: result.items.map((item) => ({ id: item.id, content: item.content, sessionId: item.sessionId, createdAt: item.createdAt })),
+            total: result.total,
+            page: result.page,
+            pages: result.pages,
+          });
+        }
+        case "query_conclusions": {
+          const peer = await honcho.peer(String(args.peer_id));
+          const scope = peer.conclusionsOf(String(args.target_peer_id ?? args.peer_id));
+          const results = await scope.query(String(args.query), typeof args.top_k === "number" ? args.top_k : undefined);
+          return json(results.map((item) => ({ id: item.id, content: item.content, sessionId: item.sessionId, createdAt: item.createdAt })));
+        }
+        case "create_conclusions": {
+          const peer = await honcho.peer(String(args.peer_id));
+          const scope = peer.conclusionsOf(String(args.target_peer_id));
+          const conclusions = Array.isArray(args.conclusions) ? args.conclusions.map(String) : [];
+          const created = await scope.create(conclusions.map((content) => ({
+            content,
+            ...(args.session_id ? { sessionId: String(args.session_id) } : {}),
+          })));
+          return json({ created: created.length, conclusions: created.map((item) => ({ id: item.id, content: item.content })) });
+        }
+        case "delete_conclusion": {
+          const peer = await honcho.peer(String(args.peer_id));
+          const scope = peer.conclusionsOf(String(args.target_peer_id));
+          await scope.delete(String(args.conclusion_id));
+          return text(`Deleted conclusion ${String(args.conclusion_id)}`);
+        }
+        default:
+          return { content: [{ type: "text", text: `Unknown tool: ${params.name}` }], isError: true };
+      }
+    } catch (error) {
+      return failure(error);
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,8 +1,8 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
-import { loadConfig, sessionName } from "../src/config.ts";
+import { honchoClientOptions, loadConfig, memoryKey, saveConfig, sessionName } from "../src/config.ts";
 
 let dir = "";
 const savedDir = process.env.HONCHO_CONFIG_DIR;
@@ -11,6 +11,12 @@ const savedKey = process.env.HONCHO_API_KEY;
 function writeConfig(obj: object) {
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, "config.json"), JSON.stringify(obj));
+}
+
+function writeLocalConfig(root: string, obj: object) {
+  const localDir = join(root, ".honcho");
+  mkdirSync(localDir, { recursive: true });
+  writeFileSync(join(localDir, "config.json"), JSON.stringify(obj));
 }
 
 beforeEach(() => {
@@ -76,6 +82,26 @@ test("session name is the slugged directory, no peer prefix", () => {
   expect(sessionName(cfg, "/Users/testuser/My Project")).toBe("my-project");
 });
 
+test("per-repo strategy uses the git root from a nested directory", () => {
+  writeConfig({ apiKey: "k", peerName: "testuser", sessionStrategy: "per-repo" });
+  const parent = mkdtempSync(join(tmpdir(), "codex-honcho-per-repo-"));
+  const repo = join(parent, "My Project");
+  const child = join(repo, "packages", "app");
+  mkdirSync(join(repo, ".git"), { recursive: true });
+  mkdirSync(child, { recursive: true });
+
+  expect(sessionName(loadConfig()!, child)).toBe("my-project");
+});
+
+test("per-repo strategy falls back to the current directory outside git", () => {
+  writeConfig({ apiKey: "k", peerName: "testuser", sessionStrategy: "per-repo" });
+  const plain = mkdtempSync(join(tmpdir(), "codex-honcho-no-repo-"));
+
+  expect(sessionName(loadConfig()!, plain)).toBe(
+    basename(plain).toLowerCase().replace(/[^a-z0-9-_]/g, "-"),
+  );
+});
+
 test("explicit session override wins", () => {
   writeConfig({ apiKey: "k", peerName: "testuser", sessions: { "/repo/x": "pinned-session" } });
   const cfg = loadConfig()!;
@@ -106,4 +132,158 @@ test("git-branch falls back to directory outside a repo", () => {
   const cfg = loadConfig()!;
   const plain = mkdtempSync(join(tmpdir(), "codex-honcho-plain-"));
   expect(sessionName(cfg, plain)).toBe(basename(plain).toLowerCase().replace(/[^a-z0-9-_]/g, "-"));
+});
+
+test("repo-local config overlays selected fields and inherits global identity", () => {
+  writeConfig({
+    apiKey: "global-key",
+    peerName: "global-user",
+    hosts: { codex: { workspace: "global-ws", aiPeer: "global-ai", reasoningLevel: "low" } },
+  });
+  const repo = mkdtempSync(join(tmpdir(), "codex-honcho-local-"));
+  const child = join(repo, "packages", "app");
+  mkdirSync(child, { recursive: true });
+  writeLocalConfig(repo, {
+    hosts: {
+      codex: {
+        workspace: "project-ws",
+        reasoningLevel: "high",
+        endpoint: { baseUrl: "http://127.0.0.1:18100" },
+      },
+    },
+  });
+
+  const cfg = loadConfig(child)!;
+  expect(cfg.apiKey).toBe("global-key");
+  expect(cfg.peerName).toBe("global-user");
+  expect(cfg.aiPeer).toBe("global-ai");
+  expect(cfg.workspace).toBe("project-ws");
+  expect(cfg.reasoningLevel).toBe("high");
+  expect(honchoClientOptions(cfg).baseURL).toBe("http://127.0.0.1:18100/v3");
+  expect(cfg.localConfig).toEqual({ path: join(repo, ".honcho", "config.json"), root: repo });
+});
+
+test("repo-local config can be fully self-contained", () => {
+  writeConfig({ peerName: "unused-global-user" });
+  const repo = mkdtempSync(join(tmpdir(), "codex-honcho-standalone-"));
+  writeLocalConfig(repo, { apiKey: "local-key", peerName: "local-user", workspace: "local-ws" });
+
+  const cfg = loadConfig(repo)!;
+  expect(cfg.apiKey).toBe("local-key");
+  expect(cfg.peerName).toBe("local-user");
+  expect(cfg.workspace).toBe("local-ws");
+});
+
+test("environment API key remains the highest-precedence override", () => {
+  writeConfig({ apiKey: "global-key", peerName: "testuser" });
+  process.env.HONCHO_API_KEY = "env-key";
+  const repo = mkdtempSync(join(tmpdir(), "codex-honcho-env-local-"));
+  writeLocalConfig(repo, { apiKey: "local-key", workspace: "local-ws" });
+
+  expect(loadConfig(repo)?.apiKey).toBe("env-key");
+});
+
+test("nearest repo-local config wins", () => {
+  writeConfig({ apiKey: "global-key", peerName: "testuser" });
+  const repo = mkdtempSync(join(tmpdir(), "codex-honcho-nearest-"));
+  const nested = join(repo, "packages", "app");
+  const child = join(nested, "src");
+  mkdirSync(child, { recursive: true });
+  writeLocalConfig(repo, { workspace: "outer-ws" });
+  writeLocalConfig(nested, { workspace: "inner-ws" });
+
+  const cfg = loadConfig(child)!;
+  expect(cfg.workspace).toBe("inner-ws");
+  expect(cfg.localConfig?.root).toBe(nested);
+});
+
+test("malformed repo-local config leaves global behavior unchanged", () => {
+  writeConfig({ apiKey: "global-key", peerName: "testuser", workspace: "global-ws" });
+  const repo = mkdtempSync(join(tmpdir(), "codex-honcho-malformed-"));
+  const localDir = join(repo, ".honcho");
+  mkdirSync(localDir, { recursive: true });
+  writeFileSync(join(localDir, "config.json"), "{not-json");
+
+  const cfg = loadConfig(repo)!;
+  expect(cfg.workspace).toBe("global-ws");
+  expect(cfg.localConfig).toBeUndefined();
+  expect(memoryKey(cfg, repo, "session-1")).toBe("session-1");
+});
+
+test("redirected global config is never mistaken for a repo-local overlay", () => {
+  const repo = mkdtempSync(join(tmpdir(), "codex-honcho-global-dir-"));
+  dir = join(repo, ".honcho");
+  process.env.HONCHO_CONFIG_DIR = dir;
+  writeConfig({ apiKey: "global-key", peerName: "testuser", workspace: "global-ws" });
+
+  const cfg = loadConfig(repo)!;
+  expect(cfg.workspace).toBe("global-ws");
+  expect(cfg.localConfig).toBeUndefined();
+});
+
+test("saveConfig writes only the global file while a local overlay is active", () => {
+  writeConfig({ apiKey: "global-key", peerName: "global-user", workspace: "global-ws" });
+  const repo = mkdtempSync(join(tmpdir(), "codex-honcho-read-only-"));
+  writeLocalConfig(repo, { workspace: "project-ws" });
+  const localPath = join(repo, ".honcho", "config.json");
+  const before = readFileSync(localPath, "utf-8");
+
+  expect(loadConfig(repo)?.workspace).toBe("project-ws");
+  saveConfig({ peerName: "updated-global-user" });
+
+  expect(readFileSync(localPath, "utf-8")).toBe(before);
+  expect(loadConfig(repo)?.workspace).toBe("project-ws");
+});
+
+test("repo-local sessions anchor to the project root", () => {
+  writeConfig({
+    apiKey: "global-key",
+    peerName: "testuser",
+    sessions: { "/ignored": "global-pinned" },
+  });
+  const parent = mkdtempSync(join(tmpdir(), "codex-honcho-anchor-"));
+  const repo = join(parent, "My Project");
+  const child = join(repo, "packages", "app");
+  mkdirSync(child, { recursive: true });
+  writeLocalConfig(repo, { workspace: "project-ws" });
+
+  const cfg = loadConfig(child)!;
+  expect(sessionName(cfg, child)).toBe("my-project");
+  expect(memoryKey(cfg, child, "session-1")).toBe("local-project-ws-session-1");
+});
+
+test("repo-local sessionName pins the exact session", () => {
+  writeConfig({ apiKey: "global-key", peerName: "testuser", sessionStrategy: "chat-instance" });
+  const repo = mkdtempSync(join(tmpdir(), "codex-honcho-pinned-"));
+  writeLocalConfig(repo, { workspace: "project-ws", sessionName: "Shared Project Memory" });
+
+  const cfg = loadConfig(repo)!;
+  expect(sessionName(cfg, join(repo, "src"), "019ea7df-805e-76d1-af52")).toBe("shared-project-memory");
+});
+
+test("splitSubmodules anchors nested git repositories independently", () => {
+  writeConfig({ apiKey: "global-key", peerName: "testuser" });
+  const repo = mkdtempSync(join(tmpdir(), "codex-honcho-submodules-"));
+  const submodule = join(repo, "modules", "Payments SDK");
+  const child = join(submodule, "src");
+  mkdirSync(child, { recursive: true });
+  mkdirSync(join(repo, ".git"), { recursive: true });
+  writeFileSync(join(submodule, ".git"), "gitdir: ../../.git/modules/payments\n");
+  writeLocalConfig(repo, { workspace: "project-ws", splitSubmodules: true });
+
+  const cfg = loadConfig(child)!;
+  expect(sessionName(cfg, child)).toBe("payments-sdk");
+});
+
+test("repo-local per-repo strategy scopes nested git repositories without splitSubmodules", () => {
+  writeConfig({ apiKey: "global-key", peerName: "testuser" });
+  const repo = mkdtempSync(join(tmpdir(), "codex-honcho-local-per-repo-"));
+  const nestedRepo = join(repo, "worktrees", "Feature Checkout");
+  const child = join(nestedRepo, "src");
+  mkdirSync(join(repo, ".git"), { recursive: true });
+  mkdirSync(child, { recursive: true });
+  writeFileSync(join(nestedRepo, ".git"), "gitdir: ../../.git/worktrees/feature\n");
+  writeLocalConfig(repo, { workspace: "project-ws", sessionStrategy: "per-repo" });
+
+  expect(sessionName(loadConfig(child)!, child)).toBe("feature-checkout");
 });

--- a/test/connectors/mcp.test.ts
+++ b/test/connectors/mcp.test.ts
@@ -1,43 +1,37 @@
 import { test, expect } from "bun:test";
-import { setMcpServer, clearMcpServer, hasMcpServer, HONCHO_MCP_URL } from "../../src/connectors/mcp.ts";
+import { setMcpServer, clearMcpServer, hasMcpServer } from "../../src/connectors/mcp.ts";
 
-const id = { apiKey: "hch-secret", userName: "testuser", workspaceId: "codex", assistantName: "codex" };
+const invoke = { command: "node", args: ["/opt/codex-honcho.mjs", "mcp"] };
 
-test("setMcpServer writes a native HTTP honcho mcp block with creds and headers", () => {
-  const out = setMcpServer("", id);
+test("setMcpServer writes a local stdio server without credentials", () => {
+  const out = setMcpServer("", invoke);
   expect(out).toContain("[mcp_servers.honcho]");
-  expect(out).toContain(`url = "${HONCHO_MCP_URL}"`);
-  // Codex rejects a top-level bearer_token for streamable_http — the key rides
-  // as an inline Authorization header inside http_headers instead.
-  expect(out).toContain('"Authorization" = "Bearer hch-secret"');
-  expect(out).not.toContain("bearer_token");
-  expect(out).toContain('"X-Honcho-User-Name" = "testuser"');
-  expect(out).toContain('"X-Honcho-Workspace-ID" = "codex"');
-  // Native transport — no mcp-remote/npx bridge.
-  expect(out).not.toContain("mcp-remote");
-  expect(out).not.toContain("command =");
+  expect(out).toContain('command = "node"');
+  expect(out).toContain('args = ["/opt/codex-honcho.mjs","mcp"]');
+  expect(out).not.toContain("hch-");
+  expect(out).not.toContain("Authorization");
+  expect(out).not.toContain("http_headers");
   expect(hasMcpServer(out)).toBe(true);
 });
 
-test("optional headers are omitted when absent", () => {
-  const out = setMcpServer("", { apiKey: "k", userName: "testuser" });
-  expect(out).not.toContain("X-Honcho-Workspace-ID");
-  expect(out).not.toContain("X-Honcho-Assistant-Name");
+test("bun development entry uses bun run", () => {
+  const out = setMcpServer("", { command: "bun", args: ["run", "/repo/bin/codex-honcho.ts", "mcp"] });
+  expect(out).toContain('command = "bun"');
+  expect(out).toContain('args = ["run","/repo/bin/codex-honcho.ts","mcp"]');
 });
 
 test("setMcpServer is idempotent — one block after repeated writes", () => {
-  let out = setMcpServer("", id);
-  out = setMcpServer(out, id);
-  out = setMcpServer(out, { ...id, apiKey: "hch-rotated" });
+  let out = setMcpServer("", invoke);
+  out = setMcpServer(out, invoke);
+  out = setMcpServer(out, { command: "node", args: ["/new/codex-honcho.mjs", "mcp"] });
   expect(out.match(/\[mcp_servers\.honcho\]/g)).toHaveLength(1);
-  // Latest creds win.
-  expect(out).toContain("hch-rotated");
-  expect(out).not.toContain("hch-secret");
+  expect(out).toContain("/new/codex-honcho.mjs");
+  expect(out).not.toContain("/opt/codex-honcho.mjs");
 });
 
 test("preserves the user's surrounding config", () => {
   const base = 'model = "o3"\n\n[features]\nhooks = true\n';
-  const out = setMcpServer(base, id);
+  const out = setMcpServer(base, invoke);
   expect(out).toContain('model = "o3"');
   expect(out).toContain("[features]");
   expect(out).toContain("[mcp_servers.honcho]");
@@ -45,7 +39,7 @@ test("preserves the user's surrounding config", () => {
 
 test("clearMcpServer removes only our block", () => {
   const base = 'model = "o3"\n';
-  const withBlock = setMcpServer(base, id);
+  const withBlock = setMcpServer(base, invoke);
   const cleared = clearMcpServer(withBlock);
   expect(hasMcpServer(cleared)).toBe(false);
   expect(cleared).toContain('model = "o3"');

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "bun:test";
+import { HONCHO_TOOLS } from "../src/mcp.ts";
+
+test("local MCP exposes the existing core Honcho memory interface", () => {
+  expect(HONCHO_TOOLS.map((tool) => tool.name)).toEqual([
+    "search",
+    "chat",
+    "get_peer_context",
+    "get_representation",
+    "list_conclusions",
+    "query_conclusions",
+    "create_conclusions",
+    "delete_conclusion",
+  ]);
+  expect(HONCHO_TOOLS.find((tool) => tool.name === "create_conclusions")?.annotations.readOnlyHint).toBe(false);
+  expect(HONCHO_TOOLS.find((tool) => tool.name === "delete_conclusion")?.annotations.destructiveHint).toBe(true);
+});


### PR DESCRIPTION
## Summary

Adds an optional repository-local `.honcho/config.json` overlay so each project can route Codex memory to its own Honcho workspace while inheriting credentials and defaults from the global `~/.honcho/config.json`.

This ports the approach from [plastic-labs/claude-honcho#44](https://github.com/plastic-labs/claude-honcho/pull/44) and adds the Hermes-compatible `per-repo` session strategy.

## Why

The Codex integration currently resolves Honcho configuration globally. When working across multiple repositories, messages, tool activity, and derived conclusions all land in the same workspace, allowing unrelated project context to bleed together.

The existing hosted MCP registration also cannot follow the active working directory: its credentials and routing are fixed in Codex configuration at install time. A local overlay would therefore affect hooks but not MCP recall tools unless MCP configuration resolution moved into a cwd-aware local process.

## How it works

- **Overlay, not replacement.** The nearest `.honcho/config.json` at or above the working directory is layered over the global config. Omitted values continue to inherit globally, so a repository file can usually contain only `{ "workspace": "my-project" }`.
- **Host-aware resolution.** Both flat fields and `hosts.codex` are supported, with environment-provided API keys retaining highest precedence.
- **Read-only repository configuration.** codex-honcho never writes the local file or copies its values into global configuration.
- **Project-root sessions.** With a local config active, session identity anchors to the directory containing `.honcho/`, preventing subdirectories from unintentionally creating separate sessions.
- **Hermes-compatible `per-repo` strategy.** All directories in the same Git repository share the Git root’s session name. Outside Git it falls back to `per-directory`; worktrees and submodules with `.git` files are supported.
- **Optional session controls.** `sessionName` pins an exact session, while `splitSubmodules` lets other strategies give nested repositories independent anchors.
- **Cwd-aware local MCP server.** Codex now launches a credential-free local stdio server that resolves the active repository configuration before calling Honcho. Hooks and MCP tools therefore use the same endpoint, workspace, and identity.
- **Isolated local state.** Queue, cursor, and context keys are namespaced by the resolved local workspace so pending global messages cannot cross into a project workspace.

## Compatibility and security

The feature is additive and opt-in. Without a repository-local `.honcho/config.json`, existing global configuration and session behavior remain unchanged.

API keys no longer need to appear in Codex’s MCP configuration. Repository files should contain only non-secret routing settings; `.env` files are explicitly ignored.

## Verification

- `bun test` — 92 tests, 207 expectations
- `bun run typecheck`
- `bun run build`
- `npm pack --dry-run`
- Local MCP handshake verified with all eight Honcho tools
- Live read-only SDK request verified against a configured self-hosted endpoint
- Staged diff and secret scans clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository-local configuration overlays with per-repository session strategies, submodule support, and isolated memory.
  * Added a credential-free local MCP server with tools for search, chat, context, representations, and conclusions.
  * MCP setup now launches the local server automatically when local configuration is available.

* **Documentation**
  * Updated setup, configuration, troubleshooting, and development guidance for local workflows.

* **Chores**
  * Added safeguards to ignore environment files while retaining the example configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->