### PR TITLE
Release 0.1.1

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-honcho",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Persistent, cross-session memory for OpenAI Codex, powered by Honcho from Plastic Labs. Lifecycle hooks capture each session and inject the relevant context back at session start, so Codex remembers your preferences, projects, and decisions across restarts and context resets.",
   "author": {
     "name": "Plastic Labs",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.1
+
+- Fixed uninstall/reinstall wiping foreign config parked inside the honcho comment fence: cleanup now removes only the marker lines and `[mcp_servers.honcho]` tables, preserving anything else Codex left there (e.g. `[hooks.state]`, tool-approval prefs).
+- Updated MCP tool names in the docs and plugin descriptions to match the server (`get_peer_context`, `create_conclusions`).
+
 ## 0.1.0
 
 - Initial release — harness-level Honcho memory for OpenAI Codex.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honcho-ai/codex-honcho",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Persistent memory for OpenAI Codex sessions using Honcho by Plastic Labs",
   "type": "module",
   "keywords": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Uninstalling and reinstalling no longer removes unrelated configuration within the Honcho section.
  * Configuration cleanup now removes only Honcho markers and settings.

* **Documentation**
  * Updated MCP tool names in documentation and plugin descriptions to match the server.

* **Chores**
  * Bumped the plugin and package versions to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->