### PR TITLE
feat: add HONCHO_HOST and HONCHO_WORKSPACE env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,21 @@ Controls how Codex conversations map to Honcho sessions:
 | `git-branch` | `my-app-main` | Feature-branch workflows where context per branch matters |
 | `chat-instance` | `my-app-019ea7df` | Ephemeral usage — a clean slate per conversation |
 
-An explicit `sessions[cwd]` mapping overrides all strategies. Environment overrides: `HONCHO_API_KEY`, `HONCHO_PEER_NAME`, `HONCHO_CONFIG_DIR`.
+An explicit `sessions[cwd]` mapping overrides all strategies. Environment overrides: `HONCHO_API_KEY`, `HONCHO_PEER_NAME`, `HONCHO_CONFIG_DIR`, `HONCHO_HOST`, `HONCHO_WORKSPACE`.
+
+### Per-Session Host Selection
+
+By default, codex-honcho reads the `hosts.codex` block from `~/.honcho/config.json`. Set `HONCHO_HOST` to select a different host block, and `HONCHO_WORKSPACE` to override the workspace directly:
+
+```bash
+# Use a custom host block (e.g. hosts.codex_reviewer)
+HONCHO_HOST=codex_reviewer codex
+
+# Override workspace without a host block
+HONCHO_WORKSPACE=team-acme codex
+```
+
+This is useful when running multiple Codex instances with different Honcho workspaces from the same machine — for example, a reviewer agent that reads from a shared review workspace while the default Codex uses a personal one. Host block lookups are underscore/hyphen insensitive, so `codex_reviewer` matches `hosts."codex-reviewer"`.
 
 ## How It Works
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,15 @@ export type SessionStrategy = "per-directory" | "git-branch" | "chat-instance";
 // it persists the resolved API key + peer name here (merging, never clobbering
 // other integrations' settings) so the shared file is the source of truth.
 
-const HOST = "codex";
+// The default host key is "codex", but HONCHO_HOST can override it so that
+// multiple codex host blocks (e.g. codex_reviewer, codex_coder) can coexist
+// in ~/.honcho/config.json and be selected per-session via environment variable.
+// This mirrors the HONCHO_HOST env var already supported by claude-honcho.
+const DEFAULT_HOST = "codex";
+
+function resolveHost(): string {
+  return process.env.HONCHO_HOST || DEFAULT_HOST;
+}
 
 function configPath(): string {
   const dir = process.env.HONCHO_CONFIG_DIR || join(homedir(), ".honcho");
@@ -79,16 +87,20 @@ export function resolvePeerName(filePeer?: string): string {
 // Returns null when there's no API key — callers exit quietly in that case.
 export function loadConfig(): Config | null {
   const raw = readFile();
-  const host = raw.hosts?.[HOST];
+  const HOST = resolveHost();
+  const host = raw.hosts?.[HOST]
+    ?? raw.hosts?.[HOST.replace(/_/g, "-")]
+    ?? raw.hosts?.[HOST.replace(/-/g, "_")];
 
   const apiKey = process.env.HONCHO_API_KEY || host?.apiKey || raw.apiKey;
   if (!apiKey) return null;
 
   const peerName = resolvePeerName(raw.peerName);
 
-  const workspace = raw.globalOverride
-    ? raw.workspace ?? HOST
-    : host?.workspace ?? raw.workspace ?? HOST;
+  const workspace = process.env.HONCHO_WORKSPACE
+    ?? (raw.globalOverride
+      ? raw.workspace ?? HOST
+      : host?.workspace ?? raw.workspace ?? HOST);
   const aiPeer = raw.globalOverride
     ? raw.aiPeer ?? HOST
     : host?.aiPeer ?? raw.aiPeer ?? HOST;
@@ -112,6 +124,7 @@ export function loadConfig(): Config | null {
 // applied). `install` uses this to decide what's missing and must be prompted.
 export function currentIdentity(): { apiKey?: string; peerName?: string } {
   const raw = readFile();
+  const HOST = resolveHost();
   return {
     apiKey: process.env.HONCHO_API_KEY || raw.hosts?.[HOST]?.apiKey || raw.apiKey,
     peerName: raw.peerName,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -107,3 +107,57 @@ test("git-branch falls back to directory outside a repo", () => {
   const plain = mkdtempSync(join(tmpdir(), "codex-honcho-plain-"));
   expect(sessionName(cfg, plain)).toBe(basename(plain).toLowerCase().replace(/[^a-z0-9-_]/g, "-"));
 });
+
+
+test("HONCHO_HOST env var selects a different host block", () => {
+  writeConfig({
+    apiKey: "root-key",
+    peerName: "testuser",
+    hosts: {
+      codex: { workspace: "default-ws", aiPeer: "codex" },
+      codex_reviewer: { workspace: "review-ws", aiPeer: "codex-reviewer" },
+    },
+  });
+  process.env.HONCHO_HOST = "codex_reviewer";
+  const cfg = loadConfig()!;
+  expect(cfg.workspace).toBe("review-ws");
+  expect(cfg.aiPeer).toBe("codex-reviewer");
+  delete process.env.HONCHO_HOST;
+});
+
+test("HONCHO_HOST with underscores resolves hyphenated host block", () => {
+  writeConfig({
+    apiKey: "root-key",
+    peerName: "testuser",
+    hosts: {
+      "codex-reviewer": { workspace: "hyphen-ws" },
+    },
+  });
+  process.env.HONCHO_HOST = "codex_reviewer";
+  const cfg = loadConfig()!;
+  expect(cfg.workspace).toBe("hyphen-ws");
+  delete process.env.HONCHO_HOST;
+});
+
+test("HONCHO_WORKSPACE env var overrides file workspace", () => {
+  writeConfig({
+    apiKey: "root-key",
+    peerName: "testuser",
+    hosts: { codex: { workspace: "file-ws" } },
+  });
+  process.env.HONCHO_WORKSPACE = "env-ws";
+  const cfg = loadConfig()!;
+  expect(cfg.workspace).toBe("env-ws");
+  delete process.env.HONCHO_WORKSPACE;
+});
+
+test("HONCHO_HOST defaults to codex when unset", () => {
+  writeConfig({
+    apiKey: "root-key",
+    peerName: "testuser",
+    hosts: { codex: { workspace: "default-ws" } },
+  });
+  // HONCHO_HOST not set — should fall back to "codex"
+  const cfg = loadConfig()!;
+  expect(cfg.workspace).toBe("default-ws");
+});


### PR DESCRIPTION
## Summary

Add per-session host block selection via `HONCHO_HOST` env var, mirroring the `HONCHO_HOST` support already available in [claude-honcho](https://github.com/plastic-labs/claude-honcho).

This enables multiple codex host blocks (e.g. `codex_reviewer`, `codex_coder`) in a single `~/.honcho/config.json`, selected per-session by environment variable. Useful when running multiple Codex instances with different Honcho workspaces from the same machine.

Also adds `HONCHO_WORKSPACE` env var for direct workspace override, and underscore/hyphen insensitive host block lookup (matching claude-honcho's `resolveConfig()`).

## Changes

- `const HOST = codex` → `resolveHost()` that reads `HONCHO_HOST` env var
- `HONCHO_WORKSPACE` env var takes priority over file workspace
- Host block lookup normalizes `_` and `-` (e.g. `codex_reviewer` matches `hosts.codex-reviewer`)
- `currentIdentity()` also uses `resolveHost()`
- 4 new tests covering all env var combinations
- README documents new env vars and per-session host selection

## Backward Compatibility

When `HONCHO_HOST` is unset, behavior is identical to before — reads `hosts.codex` block as default.

## Env Var Resolution

| Variable | Purpose | Default |
|----------|---------|---------|
| `HONCHO_HOST` | Host block key in `~/.honcho/config.json` | `codex` |
| `HONCHO_WORKSPACE` | Override workspace (bypasses host block) | unset (use host block) |
| `HONCHO_CONFIG_DIR` | Path to honcho config directory | `~/.honcho` |
| `HONCHO_API_KEY` | Override API key | unset (use file) |
| `HONCHO_PEER_NAME` | Override peer name | unset (use file) |

## Usage

```bash
# Use a custom host block (e.g. hosts.codex_reviewer)
HONCHO_HOST=codex_reviewer codex

# Override workspace without a host block
HONCHO_WORKSPACE=team-acme codex
```

## Test Plan

- [x] `bun test` passes (109 existing + 4 new tests)
- [x] HONCHO_HOST selects correct host block
- [x] HONCHO_HOST with underscores resolves hyphenated host block
- [x] HONCHO_WORKSPACE overrides file workspace
- [x] HONCHO_HOST unset → defaults to `codex` (backward compat)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-session host selection using the `HONCHO_HOST` setting.
  * Added workspace overrides through `HONCHO_WORKSPACE`.
  * Host names now support flexible underscore and hyphen matching.
  * Defaults to the `codex` host when no host is specified.

* **Documentation**
  * Updated configuration documentation with host and workspace override guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->