### PR TITLE
feat: optional ingestion policy for transcript writeback

### DIFF
--- a/src/hooks/writeback.ts
+++ b/src/hooks/writeback.ts
@@ -2,6 +2,7 @@ import { loadConfig, memoryKey } from "../config.ts";
 import { readRollout } from "../transcript/codex.ts";
 import { readCursor, writeCursor, selectNewTurns } from "../cursor.ts";
 import { enqueue } from "../queue.ts";
+import { loadPolicy, shouldDrop, capTurn } from "../policy.ts";
 import { flush } from "./flush.ts";
 
 interface WritebackInput {
@@ -12,13 +13,23 @@ interface WritebackInput {
 
 // Pure-local: pull the rollout turns not yet captured into the queue and
 // advance the rollout cursor. No network — returns how many were enqueued.
+// When an ingestion policy is configured, turns it forbids are dropped and long
+// turns are capped before enqueue; the cursor still advances past dropped turns
+// so they are never re-examined. With no policy present this is a no-op filter
+// and behaviour matches the historical default.
 export function capture(key: string, rolloutPath: string): number {
   const turns = readRollout(rolloutPath);
   const { fresh, nextCursor } = selectNewTurns(turns, readCursor(key));
   if (fresh.length === 0) return 0;
-  enqueue(key, fresh.map((t) => ({ role: t.role, text: t.text, at: t.at })));
+
+  const policy = loadPolicy();
+  const kept = fresh
+    .filter((t) => !shouldDrop(t.text, policy))
+    .map((t) => ({ role: t.role, text: capTurn(t.text, policy), at: t.at }));
+
+  if (kept.length > 0) enqueue(key, kept);
   writeCursor(key, nextCursor);
-  return fresh.length;
+  return kept.length;
 }
 
 // Stop / PreCompact (turn-scoped): capture this turn's new rollout tail into

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Optional ingestion policy. A deployment can declare which transcript turns are
+// worth storing durably and how large a single turn may be, so the rules live in
+// one reviewable file instead of being hardcoded per client.
+//
+// Resolution order:
+//   1. $HONCHO_MEMORY_POLICY (explicit path)
+//   2. ~/.honcho/memory-policy.json
+//   3. none — ingestion is unfiltered, matching the historical default.
+//
+// Patterns are plain strings compiled with `new RegExp(pattern, flags)`, so they
+// must avoid inline flag syntax such as `(?i)` that JavaScript does not accept.
+
+export interface DropRule {
+  id?: string;
+  pattern: string;
+  flags?: string;
+  reason?: string;
+}
+
+export interface IngestionPolicy {
+  maxTurnChars: number;
+  truncationMarker: string;
+  dropPatterns: RegExp[];
+}
+
+export const POLICY_ENV_VAR = "HONCHO_MEMORY_POLICY";
+export const DEFAULT_POLICY_FILENAME = "memory-policy.json";
+
+const UNFILTERED: IngestionPolicy = {
+  maxTurnChars: Number.POSITIVE_INFINITY,
+  truncationMarker: "",
+  dropPatterns: [],
+};
+
+function candidatePaths(): string[] {
+  const explicit = process.env[POLICY_ENV_VAR];
+  if (explicit) return [explicit];
+  return [join(homedir(), ".honcho", DEFAULT_POLICY_FILENAME)];
+}
+
+function compile(rules: unknown): RegExp[] {
+  if (!Array.isArray(rules)) return [];
+  const compiled: RegExp[] = [];
+  for (const rule of rules as DropRule[]) {
+    if (!rule || typeof rule.pattern !== "string") continue;
+    try {
+      compiled.push(new RegExp(rule.pattern, rule.flags ?? ""));
+    } catch {
+      // An unparseable rule is skipped rather than failing ingestion outright:
+      // a bad policy must not cost the user their session memory.
+    }
+  }
+  return compiled;
+}
+
+function parse(raw: string): IngestionPolicy {
+  const parsed = JSON.parse(raw) as { ingestion?: Record<string, unknown> };
+  const ingestion = parsed.ingestion;
+  if (!ingestion || typeof ingestion !== "object") return UNFILTERED;
+
+  const maxTurnChars =
+    typeof ingestion.max_turn_chars === "number" && ingestion.max_turn_chars > 0
+      ? ingestion.max_turn_chars
+      : Number.POSITIVE_INFINITY;
+
+  return {
+    maxTurnChars,
+    truncationMarker:
+      typeof ingestion.truncation_marker === "string"
+        ? ingestion.truncation_marker
+        : "",
+    dropPatterns: compile(ingestion.drop_patterns),
+  };
+}
+
+export function loadPolicy(): IngestionPolicy {
+  for (const path of candidatePaths()) {
+    try {
+      return parse(readFileSync(path, "utf8"));
+    } catch {
+      // Missing or malformed file — fall through to the unfiltered default.
+    }
+  }
+  return UNFILTERED;
+}
+
+export function shouldDrop(text: string, policy: IngestionPolicy): boolean {
+  return policy.dropPatterns.some((pattern) => pattern.test(text));
+}
+
+export function capTurn(text: string, policy: IngestionPolicy): string {
+  if (text.length <= policy.maxTurnChars) return text;
+  return text.slice(0, policy.maxTurnChars) + policy.truncationMarker;
+}

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -1,0 +1,92 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadPolicy, shouldDrop, capTurn, POLICY_ENV_VAR } from "../src/policy.ts";
+
+const saved = process.env[POLICY_ENV_VAR];
+let dir = "";
+
+function writePolicy(obj: object): string {
+  const path = join(dir, "memory-policy.json");
+  writeFileSync(path, JSON.stringify(obj));
+  return path;
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "codex-honcho-policy-"));
+});
+
+afterEach(() => {
+  if (saved === undefined) delete process.env[POLICY_ENV_VAR];
+  else process.env[POLICY_ENV_VAR] = saved;
+});
+
+test("no policy configured leaves ingestion unfiltered", () => {
+  process.env[POLICY_ENV_VAR] = join(dir, "does-not-exist.json");
+  const policy = loadPolicy();
+  expect(policy.dropPatterns).toHaveLength(0);
+  expect(shouldDrop("<recommended_plugins>", policy)).toBe(false);
+  expect(capTurn("x".repeat(9000), policy)).toHaveLength(9000);
+});
+
+test("malformed policy falls back to unfiltered rather than throwing", () => {
+  const path = join(dir, "memory-policy.json");
+  writeFileSync(path, "{ not json");
+  process.env[POLICY_ENV_VAR] = path;
+  expect(loadPolicy().dropPatterns).toHaveLength(0);
+});
+
+test("an unparseable rule is skipped without discarding the rest", () => {
+  process.env[POLICY_ENV_VAR] = writePolicy({
+    ingestion: {
+      drop_patterns: [{ pattern: "([unclosed" }, { pattern: "<system-reminder>" }],
+    },
+  });
+  const policy = loadPolicy();
+  expect(policy.dropPatterns).toHaveLength(1);
+  expect(shouldDrop("<system-reminder>x</system-reminder>", policy)).toBe(true);
+});
+
+test("drop patterns honour declared flags", () => {
+  process.env[POLICY_ENV_VAR] = writePolicy({
+    ingestion: {
+      drop_patterns: [{ pattern: "^#\\s*AGENTS\\.md instructions for", flags: "m" }],
+    },
+  });
+  const policy = loadPolicy();
+  expect(shouldDrop("intro\n# AGENTS.md instructions for /repo", policy)).toBe(true);
+  expect(shouldDrop("a normal decision", policy)).toBe(false);
+});
+
+test("caps over-long turns and appends the declared marker", () => {
+  process.env[POLICY_ENV_VAR] = writePolicy({
+    ingestion: { max_turn_chars: 100, truncation_marker: "…[cut]" },
+  });
+  const policy = loadPolicy();
+  const capped = capTurn("x".repeat(500), policy);
+  expect(capped).toBe("x".repeat(100) + "…[cut]");
+  expect(capTurn("short", policy)).toBe("short");
+  expect(capTurn("y".repeat(100), policy)).toBe("y".repeat(100));
+});
+
+test("a representative policy drops harness boilerplate and keeps conversation", () => {
+  process.env[POLICY_ENV_VAR] = writePolicy({
+    ingestion: {
+      max_turn_chars: 2000,
+      truncation_marker: "\n…[truncated for memory ingestion]",
+      drop_patterns: [
+        { pattern: "<recommended_plugins>" },
+        { pattern: "^#\\s*AGENTS\\.md instructions for", flags: "m" },
+        { pattern: "^#\\s*CLAUDE\\.md instructions for", flags: "m" },
+        { pattern: "<system-reminder>" },
+      ],
+    },
+  });
+  const policy = loadPolicy();
+  expect(shouldDrop("<recommended_plugins> Airtable, Asana", policy)).toBe(true);
+  expect(shouldDrop("# AGENTS.md instructions for /Users/x/repo", policy)).toBe(true);
+  expect(shouldDrop("# CLAUDE.md instructions for /Users/x/repo", policy)).toBe(true);
+  expect(shouldDrop("<system-reminder>noise</system-reminder>", policy)).toBe(true);
+  expect(shouldDrop("The payments review is now PASS.", policy)).toBe(false);
+});


### PR DESCRIPTION
## Problem

`capture()` enqueues every fresh rollout turn verbatim. On a busy agent harness a large share of those turns have no durable memory value — injected plugin catalogues, re-ingested `AGENTS.md`/`CLAUDE.md` (already authoritative in git), and system reminders — but they are still paid ingestion on every turn.

Measured on one real workspace over 13 days: **12,977 messages / 1,395,373 ingested tokens**, of which ~15% was boilerplate of that kind. Separately, 581 turns over 500 tokens accounted for ~48% of all ingested tokens, so a per-turn cap is worth as much as the drop list.

There is currently no way to express "don't store this" short of turning `saveMessages` off entirely, which loses the useful memory too.

## Change

An **opt-in** ingestion policy. Resolution order:

1. `$HONCHO_MEMORY_POLICY`
2. `~/.honcho/memory-policy.json`
3. none → ingestion is unfiltered, exactly as today

```json
{
  "ingestion": {
    "max_turn_chars": 2000,
    "truncation_marker": "\n…[truncated for memory ingestion]",
    "drop_patterns": [
      { "id": "plugin-catalogue", "pattern": "<recommended_plugins>" },
      { "id": "agents-md", "pattern": "^#\\s*AGENTS\\.md instructions for", "flags": "m" }
    ]
  }
}
```

## Notes

- **No behaviour change without a policy file**, so this is safe for existing users. `loadPolicy()` returns an unfiltered policy when nothing is configured.
- **Fails open.** A missing file, malformed JSON, or a single unparseable rule degrades to unfiltered rather than throwing — a bad policy must never cost a user their session memory. Covered by tests.
- Flags are declared in a sibling field rather than inline (`(?i)`), so the same policy file can be shared with non-JS consumers. In our case a Python-side memory gateway reads the same file, which is why the constraint exists.
- The cursor still advances past dropped turns, so they are never re-examined.

## Testing

`bun test` — 84 pass, 0 fail (6 new tests in `test/policy.test.ts` covering: no policy, malformed policy, partially-invalid rules, declared flags, capping, and marker output). `tsc --noEmit` clean.

Happy to adjust naming, the resolution order, or move the default path if you'd prefer something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ingestion policies for filtering and limiting captured conversation turns.
  * Supports policy configuration through an environment variable or local policy file.
  * Oversized turns can be truncated with customizable markers, while matching content can be excluded.

* **Bug Fixes**
  * Malformed or unavailable policies safely fall back to unfiltered ingestion.
  * Invalid filtering rules are ignored without preventing capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->