### PR TITLE
fix: correct the MCP tool names in the SessionStart hint

### DIFF
--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -13,8 +13,8 @@ const MAX_CONCLUSIONS = 8;
 // Injected once at session start so the model actively queries memory through
 // the Honcho MCP tools rather than leaning on heavy per-turn injection.
 const TOOL_HINT =
-  "Honcho memory tools are available via MCP — call honcho search / get_peer_context to recall facts " +
-  "across sessions, and honcho chat for questions about the user's history. Prefer querying over guessing.";
+  "Honcho memory tools are available via MCP — call search / get_context to recall facts " +
+  "across sessions, and chat for questions about the user's history. Prefer querying over guessing.";
 
 // SessionStart: materialize the session and surface a lean snapshot of what we
 // know, plus a nudge to use the MCP tools for anything deeper.


### PR DESCRIPTION
## Problem

`TOOL_HINT` in `src/hooks/recall.ts` names tools the Honcho MCP server does not expose:

```
"call honcho search / get_peer_context to recall facts across sessions,
 and honcho chat for questions about the user's history"
```

The server registers `search`, `chat`, `get_context`, `get_representation`, and `create_conclusion`. There is no `get_peer_context`, and the names carry no `honcho ` prefix.

Since this string is injected at SessionStart specifically to steer the model toward MCP recall, a model that follows it literally calls a non-existent tool — so the first recall attempt fails, which is the opposite of the hint's purpose.

## Change

Two words in one string constant. `search` / `get_context` / `chat`.

## Testing

`bun test` — 78 pass, 0 fail. `tsc --noEmit` clean. No behavioural code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)