### PR TITLE
feat: do not advertise the hosted dashboard when the backend is local

### DIFF
--- a/bin/codex-honcho.ts
+++ b/bin/codex-honcho.ts
@@ -12,7 +12,7 @@ import {
 } from "../src/connectors/codex.ts";
 import { installMcpServer, removeMcpServer, type McpIdentity } from "../src/connectors/mcp.ts";
 import { installSkill, removeSkill, hasSkill } from "../src/connectors/skill.ts";
-import { loadConfig, memoryKey, currentIdentity, saveConfig, resolvePeerName, sessionName, honchoSessionUrl } from "../src/config.ts";
+import { loadConfig, memoryKey, currentIdentity, saveConfig, resolvePeerName, sessionName, honchoSessionUrl, isLocalEndpoint } from "../src/config.ts";
 import { pendingCount } from "../src/queue.ts";
 
 const command = process.argv[2] ?? "";
@@ -148,11 +148,15 @@ switch (command) {
       // Deep link to inspect what actually landed server-side. We have no live
       // Codex session id here, so chat-instance can't resolve to one session —
       // link to the session for the other strategies, else the workspace view.
-      const link =
-        cfg.sessionStrategy === "chat-instance"
-          ? honchoSessionUrl(cfg.workspace, "").replace(/&session=$/, "")
-          : honchoSessionUrl(cfg.workspace, sessionName(cfg, process.cwd()));
-      console.log(`view in Honcho: ${link}`);
+      if (isLocalEndpoint(cfg)) {
+        console.log("Honcho backend: local Docker (http://127.0.0.1:8000)");
+      } else {
+        const link =
+          cfg.sessionStrategy === "chat-instance"
+            ? honchoSessionUrl(cfg.workspace, "").replace(/&session=$/, "")
+            : honchoSessionUrl(cfg.workspace, sessionName(cfg, process.cwd()));
+        console.log(`view in Honcho: ${link}`);
+      }
     }
     break;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -156,6 +156,18 @@ export function honchoClientOptions(config: Config) {
   };
 }
 
+export function isLocalEndpoint(config: Config): boolean {
+  if (config.endpoint?.environment === "local") return true;
+  const custom = config.endpoint?.baseUrl;
+  if (!custom) return false;
+  try {
+    const hostname = new URL(custom).hostname;
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
 function slug(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
 }

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -1,4 +1,4 @@
-import { loadConfig, sessionName, memoryKey, honchoSessionUrl } from "../config.ts";
+import { loadConfig, sessionName, memoryKey, honchoSessionUrl, isLocalEndpoint } from "../config.ts";
 import { createSession, renderContext } from "../memory.ts";
 import { readContext, writeContext, isStale, markInjected } from "../cache.ts";
 
@@ -39,11 +39,12 @@ export async function recall(input: RecallInput): Promise<string> {
   const block = renderContext(ctx, config.peerName, 5);
   if (block) markInjected(key, block);
 
-  // Codex surfaces SessionStart hook output to the user, so we append a deep
-  // link to this session in the Honcho GUI (parity with the Claude Code
-  // integration). We have the live session_id here, so the link is exact for
-  // every strategy — including chat-instance.
-  const link = `View this session in Honcho: ${honchoSessionUrl(config.workspace, name)}`;
+  // Codex surfaces SessionStart hook output to the user. Hosted mode gets an
+  // exact dashboard link; local mode reports the loopback backend and avoids a
+  // misleading link to the hosted Honcho UI.
+  const link = isLocalEndpoint(config)
+    ? "Honcho memory backend: local Docker (http://127.0.0.1:8000)"
+    : `View this session in Honcho: ${honchoSessionUrl(config.workspace, name)}`;
 
   const parts = [block, TOOL_HINT, link].filter(Boolean);
   return parts.join("\n");

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -2,7 +2,7 @@ import { test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
-import { loadConfig, sessionName } from "../src/config.ts";
+import { isLocalEndpoint, loadConfig, sessionName } from "../src/config.ts";
 
 let dir = "";
 const savedDir = process.env.HONCHO_CONFIG_DIR;
@@ -68,6 +68,19 @@ test("globalOverride applies flat fields across hosts", () => {
     hosts: { codex: { workspace: "ignored" } },
   });
   expect(loadConfig()!.workspace).toBe("flat-ws");
+});
+
+test("recognizes the built-in local endpoint", () => {
+  writeConfig({ apiKey: "k", peerName: "testuser", endpoint: { environment: "local" } });
+  expect(isLocalEndpoint(loadConfig()!)).toBe(true);
+});
+
+test("recognizes loopback custom endpoints but not production", () => {
+  writeConfig({ apiKey: "k", peerName: "testuser", endpoint: { baseUrl: "http://127.0.0.1:8000" } });
+  expect(isLocalEndpoint(loadConfig()!)).toBe(true);
+
+  writeConfig({ apiKey: "k", peerName: "testuser", endpoint: { baseUrl: "https://api.honcho.dev" } });
+  expect(isLocalEndpoint(loadConfig()!)).toBe(false);
 });
 
 test("session name is the slugged directory, no peer prefix", () => {


### PR DESCRIPTION
## Problem

`status` and the SessionStart `recall` hook always print an `app.honcho.dev` deep link:

```ts
const link = `View this session in Honcho: ${honchoSessionUrl(config.workspace, name)}`;
```

When `endpoint.environment` is `"local"` (or `baseUrl` points at loopback), that link resolves to a hosted workspace that holds none of the session's data. Self-hosting users get a confident link to an empty page every session — the one navigational affordance the hook offers points the wrong way.

## Change

`isLocalEndpoint(config)` recognises:
- `endpoint.environment === "local"`
- `endpoint.baseUrl` whose hostname is `localhost`, `127.0.0.1`, or `::1`

Both call sites branch on it and report the local backend instead of linking out. **Hosted deployments are unaffected** — same link, same wording as today.

## Testing

`bun test` — 80 pass, 0 fail, including 2 new cases: the built-in `local` environment, and loopback `baseUrl` vs `https://api.honcho.dev` (which must stay `false`). `tsc --noEmit` clean.

## Note

Independent of #17, which corrects the MCP tool names in the same file. The two touch different hunks and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)