### PR TITLE
Filter injected recommended plugins context

### DIFF
--- a/src/transcript/codex.ts
+++ b/src/transcript/codex.ts
@@ -42,6 +42,7 @@ const CODEX_SYSTEM_TAGS = [
   "user_instructions",
   "apps_instructions",
   "plugins_instructions",
+  "recommended_plugins",
   "skills_instructions",
   "collaboration_mode",
 ];

--- a/test/transcript/codex.test.ts
+++ b/test/transcript/codex.test.ts
@@ -69,6 +69,24 @@ test("drops Codex-injected system turns (environment_context, etc.)", () => {
   expect(turns[0].text).toBe("actual question from me");
 });
 
+test("drops recommended_plugins system turn", () => {
+  const path = writeRollout([
+    { type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "<recommended_plugins>\n  <plugin id=\"honcho\"/>\n</recommended_plugins>" }] } },
+    { type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "user message" }] } },
+  ]);
+  const turns = readRollout(path);
+  expect(turns).toHaveLength(1);
+  expect(turns[0].text).toBe("user message");
+});
+
+test("drops recommended_plugins variant with attributes", () => {
+  const path = writeRollout([
+    { type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "<recommended_plugins version=\"2\">list</recommended_plugins>" }] } },
+  ]);
+  const turns = readRollout(path);
+  expect(turns).toHaveLength(0);
+});
+
 test("skips malformed lines without throwing", () => {
   const path = writeRollout([
     { type: "session_meta", payload: { cwd: "/tmp/x" } },


### PR DESCRIPTION
## Summary
- reproduce Codex lifecycle input containing an injected `<recommended_plugins>` block
- filter that system-owned block through the existing shared `CODEX_SYSTEM_TAGS` parser path
- retain the real user turn and preserve the existing size, secret, and idempotency boundaries

## TDD evidence
- RED: `44ac596` adds plain-tag and attributed-tag regression cases; the original parser retained two turns
- GREEN: `207efdf` adds `recommended_plugins` to the existing system-tag allowlist; the fixed parser retains only the real user turn

## Verification
- `npm ci --ignore-scripts`
- `npm run typecheck` PASS
- `npm run build` PASS
- metadata-only esbuild RED/GREEN harness PASS

Bun was not installed on the verification machine, so the repository's Bun-native test runner was not claimed as executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation history handling by excluding internal recommended-plugin messages from persisted turns.
  * Preserved relevant user conversation content while removing unsupported system-message variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->