### PR TITLE
Protect captured memory from credential leaks and session collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Redact common credential formats before durable queue writes and again before upload.
+- Stop retaining raw shell commands, patches, paths, responses, and tool arguments in tool observations.
+
 ## 0.1.1
 
 - Fixed uninstall/reinstall wiping foreign config parked inside the honcho comment fence: cleanup now removes only the marker lines and `[mcp_servers.honcho]` tables, preserving anything else Codex left there (e.g. `[hooks.state]`, tool-approval prefs).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Give Codex long-term memory that survives context resets, session restarts, and 
 - **Git Awareness** — Optionally scope memory per branch, so feature work keeps its own context
 - **Flexible Sessions** — Map memory per directory, per git branch, or per chat instance
 - **Local-First Capture** — Conversations are queued to disk instantly and uploaded in the background — capture never blocks your turn or hits the network mid-conversation
+- **Credential Redaction** — Common token, auth header, cookie, JWT, private-key, URL credential, and sensitive key/value forms are redacted before queueing and again before upload
 - **Cross-Tool Context** — Shares `~/.honcho/config.json` with other Honcho integrations (Claude Code, Cursor, …), so context can follow you between tools
 
 ## Prerequisites
@@ -161,6 +162,12 @@ The plugin hooks into Codex's lifecycle events:
 - **UserPromptSubmit** (`prompt`) — optional per-turn context injection (off by default; the MCP tools cover depth)
 - **PostToolUse** (`observe`) — appends a one-line note for significant tool calls to the local queue
 - **Stop / PreCompact** (`writeback`) — captures the new transcript tail, then flushes the queue to Honcho
+
+Redaction is a defense-in-depth heuristic, not a guarantee that every secret
+format will be recognized. Tool memory stores only generic activity labels and
+never raw commands, patches, paths, responses, or arguments. Avoid pasting
+credentials into chat and review the local queue before enabling capture for
+sensitive environments; see [SECURITY.md](./SECURITY.md).
 
 Capture is **local-first**: hooks only ever append to a plain JSONL queue, so they're instant and never touch the network. The flush is lock-guarded and advances a per-chunk sent marker, so a failed or partial upload simply stays queued and retries on the next turn. Inspect the local queue any time with `tail -f ~/.honcho/codex/queue/*.jsonl`, and run `codex-honcho status` to see the pending depth plus a deep link to your session in the Honcho GUI to confirm what landed server-side.
 

--- a/README.md
+++ b/README.md
@@ -231,3 +231,7 @@ MIT — see [LICENSE](LICENSE)
 - **Discord**: [Join the community](https://discord.gg/plasticlabs)
 - **X**: [@honchodotdev](https://x.com/honchodotdev)
 - **Plastic Labs**: [plasticlabs.ai](https://plasticlabs.ai)
+
+### Chat-instance identity
+
+Chat-instance sessions preserve the full Codex session identifier. Truncating timestamp-based IDs can merge independent conversations started close together. Existing shortened sessions remain available in Honcho; new writes use the full identifier.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,26 @@ The integration sends your session content to the Honcho API for memory
 storage. Review [Honcho's privacy and security posture](https://honcho.dev)
 before connecting accounts that contain sensitive data.
 
+## Credential redaction
+
+When message capture is enabled, codex-honcho redacts common credential forms
+before writing them to the local queue and applies the same filter again before
+upload. This includes common provider token prefixes, authorization and cookie
+headers, JWTs, private-key PEM blocks, URL credentials, and values assigned to
+sensitive key names. Tool observations never retain raw commands, patches,
+paths, responses, or other tool arguments.
+
+The queue directory is forced to mode `0700`; queue, sent-marker, and lock files
+are forced to mode `0600`. Files created by earlier releases are tightened in
+place when they are read or updated, without copying their contents.
+
+Redaction is heuristic. It reduces accidental credential persistence but cannot
+recognize every proprietary or newly introduced secret format. Do not paste
+secrets into prompts, and review the local queue before enabling capture in an
+environment that handles credentials or regulated data. Previously queued
+entries remain unchanged on disk, although current releases redact them again
+at the upload boundary.
+
 ## Supported versions
 
 The latest published release on npm (`@honcho-ai/codex-honcho`) is supported.

--- a/src/config.ts
+++ b/src/config.ts
@@ -164,7 +164,7 @@ function slug(s: string): string {
 // derived per strategy:
 //   per-directory  → <repo>                 (one session per project dir)
 //   git-branch     → <repo>-<branch>        (per branch; falls back to repo)
-//   chat-instance  → <repo>-<short id>      (one session per Codex conversation)
+//   chat-instance  → <repo>-<full id>      (one session per Codex conversation)
 // No peer prefix — the workspace already isolates a user's data.
 export function sessionName(config: Config, cwd: string, sessionId?: string): string {
   const override = config.sessions?.[cwd];
@@ -177,7 +177,7 @@ export function sessionName(config: Config, cwd: string, sessionId?: string): st
       return branch ? `${repo}-${slug(branch)}` : repo;
     }
     case "chat-instance":
-      return sessionId ? `${repo}-${slug(sessionId).slice(0, 8)}` : repo;
+      return sessionId ? `${repo}-${slug(sessionId)}` : repo;
     case "per-directory":
     default:
       return repo;

--- a/src/hooks/flush.ts
+++ b/src/hooks/flush.ts
@@ -1,8 +1,9 @@
 import { join } from "node:path";
-import { mkdirSync, writeFileSync, unlinkSync, readFileSync } from "node:fs";
+import { chmodSync, writeFileSync, unlinkSync, readFileSync } from "node:fs";
 import { loadConfig, sessionName, memoryKey } from "../config.ts";
 import { getSession } from "../memory.ts";
-import { readQueue, sentCount, setSentCount, queueDir, safe, type QueueEntry } from "../queue.ts";
+import { readQueue, sentCount, setSentCount, queueDir, safe, secureQueueStorage, type QueueEntry } from "../queue.ts";
+import { redactSensitiveText } from "../redact.ts";
 
 interface FlushInput {
   cwd?: string;
@@ -65,7 +66,10 @@ function messagesForEntry(
   aiPeer: SessionHandles["aiPeer"],
 ): PeerMessage[] {
   const peer = entry.role === "user" ? userPeer : aiPeer;
-  const body = entry.role === "tool" ? `[tool] ${entry.text}` : entry.text;
+  // Re-redact at the network boundary so queue files created by older versions
+  // cannot upload a credential after this version is installed.
+  const safeText = redactSensitiveText(entry.text);
+  const body = entry.role === "tool" ? `[tool] ${safeText}` : safeText;
   return chunkText(body).map((piece) =>
     peer.message(piece, {
       createdAt: entry.at,
@@ -79,8 +83,9 @@ function messagesForEntry(
 function acquireLock(key: string): boolean {
   const path = lockPath(key);
   try {
-    mkdirSync(queueDir(), { recursive: true });
-    writeFileSync(path, String(process.pid), { flag: "wx" });
+    secureQueueStorage();
+    writeFileSync(path, String(process.pid), { flag: "wx", mode: 0o600 });
+    try { chmodSync(path, 0o600); } catch {}
     return true;
   } catch {
     try {
@@ -89,7 +94,8 @@ function acquireLock(key: string): boolean {
       return false;
     } catch {
       try {
-        writeFileSync(path, String(process.pid));
+        writeFileSync(path, String(process.pid), { mode: 0o600 });
+        try { chmodSync(path, 0o600); } catch {}
         return true;
       } catch {
         return false;

--- a/src/hooks/observe.ts
+++ b/src/hooks/observe.ts
@@ -31,6 +31,8 @@ function shellCommand(input: Record<string, unknown>): string {
 }
 
 // Pure: a one-line observation for a tool call, or "" if not worth recording.
+// Tool arguments are inspected only to classify trivial calls; no raw command,
+// patch, path, response, or other tool payload is returned to the memory queue.
 export function summarizeTool(name: string, input: Record<string, unknown>): string {
   if (!name) return "";
 
@@ -42,13 +44,10 @@ export function summarizeTool(name: string, input: Record<string, unknown>): str
     const cmd = shellCommand(input).trim();
     if (!cmd) return "";
     if (TRIVIAL_SHELL.some((t) => cmd === t || cmd.startsWith(t + " "))) return "";
-    return `ran: ${cmd.slice(0, 120)}`;
+    return "ran a shell command";
   }
 
   if (name === "apply_patch") {
-    const patch = typeof input.input === "string" ? input.input : typeof input.patch === "string" ? input.patch : "";
-    const files = [...patch.matchAll(/^\*\*\* (?:Add|Update|Delete) File: (.+)$/gm)].map((m) => m[1]);
-    if (files.length) return `edited: ${files.slice(0, 5).join(", ")}`;
     return "applied a patch";
   }
 

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, chmodSync } from "node:fs";
+import { redactSensitiveText } from "./redact.ts";
 
 // A durable, human-readable outbox. Capture hooks append here instantly (local,
 // no network) so everything recorded is visible live (`tail -f`); a background
@@ -32,16 +33,35 @@ function sentPath(key: string): string {
   return join(queueDir(), `${safe(key)}.sent`);
 }
 
+export function secureQueueStorage(): void {
+  const dir = queueDir();
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // Tighten a directory created by an older release without inspecting or
+  // copying any queued content.
+  try { chmodSync(dir, 0o700); } catch {}
+}
+
+function secureFile(path: string): void {
+  // Tighten existing queue/sent files in place; do not rewrite their content.
+  try { chmodSync(path, 0o600); } catch {}
+}
+
 export function enqueue(key: string, entries: QueueEntry[]): void {
   if (entries.length === 0) return;
-  mkdirSync(queueDir(), { recursive: true });
-  appendFileSync(queuePath(key), entries.map((e) => JSON.stringify(e)).join("\n") + "\n");
+  secureQueueStorage();
+  const safeEntries = entries.map((entry) => ({ ...entry, text: redactSensitiveText(entry.text) }));
+  const path = queuePath(key);
+  appendFileSync(path, safeEntries.map((e) => JSON.stringify(e)).join("\n") + "\n", { mode: 0o600 });
+  secureFile(path);
 }
 
 export function readQueue(key: string): QueueEntry[] {
+  const path = queuePath(key);
+  secureQueueStorage();
+  secureFile(path);
   let raw: string;
   try {
-    raw = readFileSync(queuePath(key), "utf-8");
+    raw = readFileSync(path, "utf-8");
   } catch {
     return [];
   }
@@ -59,8 +79,11 @@ export function readQueue(key: string): QueueEntry[] {
 }
 
 export function sentCount(key: string): number {
+  const path = sentPath(key);
+  secureQueueStorage();
+  secureFile(path);
   try {
-    const n = parseInt(readFileSync(sentPath(key), "utf-8").trim(), 10);
+    const n = parseInt(readFileSync(path, "utf-8").trim(), 10);
     return Number.isFinite(n) && n >= 0 ? n : 0;
   } catch {
     return 0;
@@ -68,8 +91,10 @@ export function sentCount(key: string): number {
 }
 
 export function setSentCount(key: string, n: number): void {
-  mkdirSync(queueDir(), { recursive: true });
-  writeFileSync(sentPath(key), String(n));
+  secureQueueStorage();
+  const path = sentPath(key);
+  writeFileSync(path, String(n), { mode: 0o600 });
+  secureFile(path);
 }
 
 // Entries captured but not yet confirmed sent to Honcho.

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,60 @@
+const REDACTED = "[REDACTED]";
+
+// Redaction is deliberately applied before durable queue writes and again at
+// the upload boundary. It is heuristic rather than a data-loss-prevention
+// guarantee, but it covers the credential formats most often pasted into chat.
+const KNOWN_SECRET_PATTERNS: RegExp[] = [
+  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g,
+  /\bGOCSPX-[A-Za-z0-9_-]{16,}\b/g,
+  /\bAIza[A-Za-z0-9_-]{30,}\b/g,
+  /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-(?:proj-|or-v1-)?[A-Za-z0-9_-]{20,}\b/g,
+  /\bhch-[A-Za-z0-9_-]{16,}\b/g,
+  /\bAKIA[A-Z0-9]{16}\b/g,
+  /\bxox[a-zA-Z]-[A-Za-z0-9-]{20,}\b/g,
+  /\bsk_live_[A-Za-z0-9]{16,}\b/g,
+  /\bSG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\b/g,
+];
+
+const SENSITIVE_SUFFIX =
+  "api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|bearer[_-]?token|client[_-]?secret|private[_-]?key|password|passwd|secret";
+const SENSITIVE_KEY =
+  `(?:[A-Za-z0-9]+[_-])*(?:${SENSITIVE_SUFFIX})|authorization|proxy-authorization|cookie|set-cookie|ct0|twid|guest[_-]?id|personalization[_-]?id|kdt|csrf[_-]?token|xsrf[_-]?token|x-csrf-token|x-xsrf-token`;
+function redactUnstructuredText(input: string): string {
+  if (!input) return input;
+  let text = input;
+
+  text = text.replace(
+    /-----BEGIN (?:RSA |EC |OPENSSH |ENCRYPTED )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |OPENSSH |ENCRYPTED )?PRIVATE KEY-----/g,
+    `[PRIVATE KEY ${REDACTED}]`,
+  );
+  text = text.replace(/\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/g, `[JWT ${REDACTED}]`);
+  for (const pattern of KNOWN_SECRET_PATTERNS) text = text.replace(pattern, REDACTED);
+
+  // Redact the whole credential part regardless of auth scheme. Limiting this
+  // to Bearer/Basic leaves opaque Token, Digest, Negotiate, and custom schemes.
+  text = text.replace(/^((?:Proxy-)?Authorization\s*:\s*).+$/gim, `$1${REDACTED}`);
+  text = text.replace(/\b(Bearer|Basic)\s+[A-Za-z0-9+/=_:.-]{8,}/gi, `$1 ${REDACTED}`);
+  text = text.replace(/^((?:Cookie|Set-Cookie)\s*:\s*).+$/gim, `$1${REDACTED}`);
+  text = text.replace(/\bhttps?:\/\/[^\s/@:]+:[^\s/@]+@/gi, (match) => `${match.split("://")[0]}://${REDACTED}@`);
+  text = text.replace(new RegExp(`([?&](?:${SENSITIVE_KEY})=)[^&#\\s]+`, "gi"), `$1${REDACTED}`);
+  text = text.replace(
+    new RegExp(`((?:["']?)\\b(?:${SENSITIVE_KEY})\\b(?:["']?)\\s*[:=]\\s*)("(?:\\\\.|[^"\\\\])*"|'(?:\\\\.|[^'\\\\])*')`, "gi"),
+    (_match, prefix: string, value: string) => `${prefix}${value[0]}${REDACTED}${value[0]}`,
+  );
+  text = text.replace(new RegExp(`((?:["']?)\\b(?:${SENSITIVE_KEY})\\b(?:["']?)\\s*[:=]\\s*)(?!["']|\\[REDACTED\\])([^\\s,;}{]+)`, "gi"), `$1${REDACTED}`);
+  text = text.replace(
+    /(--(?:api-key|token|password|secret|client-secret)\s+)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s]+)/gi,
+    (_match, prefix: string, value: string) => {
+      const quote = value[0] === '"' || value[0] === "'" ? value[0] : "";
+      return `${prefix}${quote}${REDACTED}${quote}`;
+    },
+  );
+
+  return text;
+}
+
+export function redactSensitiveText(input: string): string {
+  return redactUnstructuredText(input);
+}

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -82,10 +82,10 @@ test("explicit session override wins", () => {
   expect(sessionName(cfg, "/repo/x")).toBe("pinned-session");
 });
 
-test("chat-instance strategy appends a short Codex session id", () => {
+test("chat-instance strategy preserves the complete Codex session id", () => {
   writeConfig({ apiKey: "k", peerName: "testuser", hosts: { codex: { sessionStrategy: "chat-instance" } } });
   const cfg = loadConfig()!;
-  expect(sessionName(cfg, "/repo/my-app", "019ea7df-805e-76d1-af52")).toBe("my-app-019ea7df");
+  expect(sessionName(cfg, "/repo/my-app", "019ea7df-805e-76d1-af52")).toBe("my-app-019ea7df-805e-76d1-af52");
   // No session id → falls back to the directory.
   expect(sessionName(cfg, "/repo/my-app")).toBe("my-app");
 });
@@ -106,4 +106,14 @@ test("git-branch falls back to directory outside a repo", () => {
   const cfg = loadConfig()!;
   const plain = mkdtempSync(join(tmpdir(), "codex-honcho-plain-"));
   expect(sessionName(cfg, plain)).toBe(basename(plain).toLowerCase().replace(/[^a-z0-9-_]/g, "-"));
+});
+
+
+test("chat instances sharing a timestamp prefix remain separate", () => {
+  writeConfig({ apiKey: "k", peerName: "testuser", hosts: { codex: { sessionStrategy: "chat-instance" } } });
+  const cfg = loadConfig()!;
+  const first = "00000000-0000-4000-8000-000000000001";
+  const second = "00000000-0000-4000-8000-000000000002";
+  expect(sessionName(cfg, "/repo/my-app", first)).not.toBe(sessionName(cfg, "/repo/my-app", second));
+  expect(sessionName(cfg, "/repo/my-app", first)).toBe(`my-app-${first}`);
 });

--- a/test/hooks/flush.test.ts
+++ b/test/hooks/flush.test.ts
@@ -231,3 +231,17 @@ test("does not upload when saveMessages is disabled", async () => {
   expect(addCalls).toBe(0);
   expect(sentCount("s1")).toBe(0);
 });
+
+test("re-redacts legacy queue content at the network boundary", async () => {
+  const secret = `hch-${"Qw7".repeat(8)}`;
+  // Simulate an entry written by a pre-redaction release by bypassing enqueue.
+  const queueFile = join(dir, "codex", "queue", "s1.jsonl");
+  const { mkdirSync } = await import("node:fs");
+  mkdirSync(join(dir, "codex", "queue"), { recursive: true });
+  writeFileSync(queueFile, JSON.stringify({ role: "user", text: `apiKey=${secret}` }) + "\n");
+
+  await runFlush();
+  const uploaded = batches.flat().map((message) => message.text).join("\n");
+  expect(uploaded).not.toContain(secret);
+  expect(uploaded).toContain("apiKey=[REDACTED]");
+});

--- a/test/hooks/observe.test.ts
+++ b/test/hooks/observe.test.ts
@@ -2,11 +2,11 @@ import { test, expect } from "bun:test";
 import { summarizeTool } from "../../src/hooks/observe.ts";
 
 test("summarizes a shell command from an argv array", () => {
-  expect(summarizeTool("shell", { command: ["npm", "run", "build"] })).toBe("ran: npm run build");
+  expect(summarizeTool("shell", { command: ["npm", "run", "build"] })).toBe("ran a shell command");
 });
 
 test("summarizes a shell command from a string", () => {
-  expect(summarizeTool("local_shell", { command: "bun test" })).toBe("ran: bun test");
+  expect(summarizeTool("local_shell", { command: "bun test" })).toBe("ran a shell command");
 });
 
 test("drops trivial read-only shell commands", () => {
@@ -16,7 +16,7 @@ test("drops trivial read-only shell commands", () => {
 
 test("matches Codex's 'Bash' tool name (the flood bug) and filters read-only", () => {
   // Codex sends tool_name "Bash" — these must be summarized, not fall through.
-  expect(summarizeTool("Bash", { command: "npm run build" })).toBe("ran: npm run build");
+  expect(summarizeTool("Bash", { command: "npm run build" })).toBe("ran a shell command");
   // ...and read-only ones must be dropped, not recorded as "used Bash".
   expect(summarizeTool("Bash", { command: "grep -r foo src" })).toBe("");
   expect(summarizeTool("Bash", { command: "find . -name '*.ts'" })).toBe("");
@@ -25,12 +25,17 @@ test("matches Codex's 'Bash' tool name (the flood bug) and filters read-only", (
 
 test("trivial match respects word boundaries", () => {
   // "catalog" must not be skipped just because it starts with "cat".
-  expect(summarizeTool("Bash", { command: "catalog --build" })).toBe("ran: catalog --build");
+  expect(summarizeTool("Bash", { command: "catalog --build" })).toBe("ran a shell command");
 });
 
-test("extracts edited files from an apply_patch", () => {
+test("does not retain patch contents or edited paths", () => {
   const patch = "*** Begin Patch\n*** Update File: src/a.ts\n+x\n*** Add File: src/b.ts\n+y\n*** End Patch";
-  expect(summarizeTool("apply_patch", { input: patch })).toBe("edited: src/a.ts, src/b.ts");
+  expect(summarizeTool("apply_patch", { input: patch })).toBe("applied a patch");
+});
+
+test("does not retain secrets embedded in a shell command", () => {
+  const command = `deploy --token ghp_${"Ab3".repeat(10)}`;
+  expect(summarizeTool("Bash", { command })).toBe("ran a shell command");
 });
 
 test("falls back to a generic note for unknown tools", () => {

--- a/test/hooks/writeback.test.ts
+++ b/test/hooks/writeback.test.ts
@@ -54,3 +54,16 @@ test("capture skips Codex-injected system turns", () => {
   expect(capture("s2", rollout)).toBe(1);
   expect(readQueue("s2").map((e) => e.text)).toEqual(["real prompt"]);
 });
+
+test("capture redacts secrets before writing the local queue", () => {
+  const secret = `hch-${"Qw7".repeat(8)}`;
+  writeRollout([
+    { role: "user", text: `Please use api_key=${secret} for this request` },
+    { role: "assistant", text: `I will not repeat ${secret}` },
+  ]);
+  expect(capture("s3", rollout)).toBe(2);
+  const queued = readQueue("s3").map((e) => e.text);
+  expect(queued.join("\n")).not.toContain(secret);
+  expect(queued[0]).toContain("Please use api_key=[REDACTED]");
+  expect(queued[1]).toContain("I will not repeat [REDACTED]");
+});

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { enqueue, readQueue, pending, pendingCount, sentCount, setSentCount } from "../src/queue.ts";
@@ -46,4 +46,47 @@ test("empty enqueue is a no-op", () => {
 test("missing queue reads as empty", () => {
   expect(readQueue("nope")).toEqual([]);
   expect(pendingCount("nope")).toBe(0);
+});
+
+test("enqueue redacts secrets at the durable storage boundary", () => {
+  const secret = `hch-${"Qw7".repeat(8)}`;
+  enqueue("k", [{ role: "user", text: `credential=${secret}` }]);
+  const text = readQueue("k")[0].text;
+  expect(text).not.toContain(secret);
+  expect(text).toContain("[REDACTED]");
+});
+
+test("queue directory and new queue/sent files use private permissions", () => {
+  enqueue("private", [{ role: "user", text: "hello" }]);
+  setSentCount("private", 1);
+  const root = join(process.env.HONCHO_CONFIG_DIR!, "codex", "queue");
+  expect(statSync(root).mode & 0o777).toBe(0o700);
+  expect(statSync(join(root, "private.jsonl")).mode & 0o777).toBe(0o600);
+  expect(statSync(join(root, "private.sent")).mode & 0o777).toBe(0o600);
+});
+
+test("enqueue tightens permissions created by an older release in place", () => {
+  const root = join(process.env.HONCHO_CONFIG_DIR!, "codex", "queue");
+  mkdirSync(root, { recursive: true, mode: 0o755 });
+  chmodSync(root, 0o755);
+  enqueue("legacy", [{ role: "user", text: "preserved" }]);
+  expect(statSync(root).mode & 0o777).toBe(0o700);
+  expect(statSync(join(root, "legacy.jsonl")).mode & 0o777).toBe(0o600);
+  expect(readQueue("legacy")[0].text).toBe("preserved");
+});
+
+test("readback tightens existing queue and sent files without rewriting content", () => {
+  const root = join(process.env.HONCHO_CONFIG_DIR!, "codex", "queue");
+  mkdirSync(root, { recursive: true, mode: 0o755 });
+  const queue = join(root, "old.jsonl");
+  const sent = join(root, "old.sent");
+  writeFileSync(queue, `${JSON.stringify({ role: "user", text: "legacy text" })}\n`, { mode: 0o644 });
+  writeFileSync(sent, "0", { mode: 0o644 });
+  chmodSync(queue, 0o644);
+  chmodSync(sent, 0o644);
+
+  expect(readQueue("old")[0].text).toBe("legacy text");
+  expect(sentCount("old")).toBe(0);
+  expect(statSync(queue).mode & 0o777).toBe(0o600);
+  expect(statSync(sent).mode & 0o777).toBe(0o600);
 });

--- a/test/redact.test.ts
+++ b/test/redact.test.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "bun:test";
+import { redactSensitiveText } from "../src/redact.ts";
+
+const github = `ghp_${"Ab3".repeat(10)}`;
+const honcho = `hch-${"Qw7".repeat(8)}`;
+const jwt = `eyJ${"a".repeat(10)}.${"b".repeat(12)}.${"c".repeat(14)}`;
+
+test("redacts common provider credentials while preserving surrounding prose", () => {
+  const input = `Use ${github} for the existing integration and keep the project name atlas.`;
+  const output = redactSensitiveText(input);
+  expect(output).toBe("Use [REDACTED] for the existing integration and keep the project name atlas.");
+  expect(output).not.toContain(github);
+});
+
+test("redacts JSON, env, header, CLI, URL, cookie, JWT, and PEM forms", () => {
+  const samples = [
+    `{"apiKey":"${honcho}","project":"atlas"}`,
+    `ACCESS_TOKEN=${github}\nSAFE_NAME=atlas`,
+    `Authorization: Bearer ${honcho}`,
+    `Cookie: session=${honcho}; theme=dark`,
+    `tool --client-secret ${honcho} --mode safe`,
+    `https://user:${honcho}@example.test/path`,
+    `https://example.test/?api_key=${honcho}&page=2`,
+    jwt,
+    `-----BEGIN PRIVATE KEY-----\n${honcho}\n-----END PRIVATE KEY-----`,
+  ];
+  for (const sample of samples) {
+    const output = redactSensitiveText(sample);
+    expect(output).not.toContain(honcho);
+    expect(output).not.toContain(github);
+    expect(output).not.toContain(jwt);
+  }
+});
+
+test("keeps redacted JSON syntactically valid", () => {
+  const output = redactSensitiveText(JSON.stringify({ apiKey: honcho, project: "atlas" }));
+  expect(JSON.parse(output)).toEqual({ apiKey: "[REDACTED]", project: "atlas" });
+});
+
+test("redacts opaque values behind quoted JSON keys", () => {
+  const input = JSON.stringify({ api_key: "opaque-value", Cookie: "session=opaque", project: "atlas" });
+  expect(JSON.parse(redactSensitiveText(input))).toEqual({
+    api_key: "[REDACTED]",
+    Cookie: "[REDACTED]",
+    project: "atlas",
+  });
+});
+
+test("redacts prefixed environment keys and opaque X cookie fields", () => {
+  const input = [
+    "N8N_API_KEY=opaque-n8n-value",
+    "CT0=opaque-csrf-cookie",
+    "AUTH_TOKEN=opaque-auth-cookie",
+    "TWID=opaque-account-cookie",
+    "SAFE_NAME=atlas",
+  ].join("\n");
+  const output = redactSensitiveText(input);
+  expect(output).toContain("N8N_API_KEY=[REDACTED]");
+  expect(output).toContain("CT0=[REDACTED]");
+  expect(output).toContain("AUTH_TOKEN=[REDACTED]");
+  expect(output).toContain("TWID=[REDACTED]");
+  expect(output).toContain("SAFE_NAME=atlas");
+  expect(output).not.toContain("opaque-");
+});
+
+test("redacts complete Authorization headers for opaque schemes", () => {
+  const input = [
+    "Authorization: Token opaque-primary-credential",
+    "Proxy-Authorization: Digest opaque-proxy-credential",
+    "X-Request-ID: public-request-id",
+  ].join("\n");
+  const output = redactSensitiveText(input);
+  expect(output).toContain("Authorization: [REDACTED]");
+  expect(output).toContain("Proxy-Authorization: [REDACTED]");
+  expect(output).toContain("X-Request-ID: public-request-id");
+  expect(output).not.toContain("opaque-");
+});
+
+test("redacts JSON strings containing escaped quotes without breaking JSON", () => {
+  const input = JSON.stringify({ password: 'prefix"suffix', nested: { N8N_API_KEY: "opaque" }, safe: "atlas" });
+  const output = redactSensitiveText(input);
+  expect(JSON.parse(output)).toEqual({ password: "[REDACTED]", nested: { N8N_API_KEY: "[REDACTED]" }, safe: "atlas" });
+});
+
+test("preserves safe JSON byte-for-byte, including large integers and duplicate keys", () => {
+  const input = `{
+  "safe": "atlas",
+  "large_id": 900719925474099312345,
+  "duplicate": 1,
+  "duplicate": 2
+}`;
+  expect(redactSensitiveText(input)).toBe(input);
+});
+
+test("redacts quoted CLI secret arguments including spaces", () => {
+  const output = redactSensitiveText(`deploy --password "prefix suffix" --client-secret 'other value' --mode safe`);
+  expect(output).toBe(`deploy --password "[REDACTED]" --client-secret '[REDACTED]' --mode safe`);
+});
+
+test("does not erase ordinary ids, paths, prose, or code", () => {
+  const input = "Session 00000000-0000-4000-8000-000000000000 edits src/auth.ts for project atlas.";
+  expect(redactSensitiveText(input)).toBe(input);
+});
+
+test("is idempotent", () => {
+  const once = redactSensitiveText(`api_key=${honcho}`);
+  expect(redactSensitiveText(once)).toBe(once);
+});


### PR DESCRIPTION
## Problem

Memory capture currently persists full message text and raw tool observations. Credentials pasted into a conversation can reach both the local queue and Honcho uploads.

## Change

- Redact common credential forms before queue writes and again before uploads, including existing queued entries.
- Keep tool observations as activity labels without raw commands, patches, paths, or arguments.
- Restrict queue directories to 0700 and queue, sent-marker and lock files covered by this change to 0600.
- Preserve text formatting, large numeric identifiers, and duplicate JSON keys when no redaction is needed.
- Document that pattern-based redaction is heuristic, not a guarantee for every proprietary secret format.

- Preserve full Codex session identifiers in chat-instance mode: truncating timestamp-based UUIDs can merge independent conversations started close together. Existing shortened sessions remain available; new writes use the full identifier.

## Validation

- 97 tests passed, 0 failures (245 assertions).
- Typecheck, build, and `git diff --check` passed.
- Regression coverage includes quoted and escaped JSON/CLI values, authorization schemes, opaque cookies, restrictive file modes, and unchanged non-sensitive JSON.

The patch uses synthetic fixtures and contains no personal configuration or conversation data.
